### PR TITLE
fix: SQL query generation for tag-only and Query.all() queries

### DIFF
--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.append.tests.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.append.tests.ts
@@ -172,6 +172,129 @@ describe("postgresEventStore.append", () => {
         })
     })
 
+    describe("when append condition uses Query.all()", () => {
+        test("should successfully append when no prior events exist", async () => {
+            const appendCondition: AppendCondition = {
+                query: Query.all(),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)
+            const events = await streamAllEventsToArray(eventStore.read(Query.all()))
+            expect(events.length).toBe(1)
+        })
+
+        test("should reject append when prior events exceed expectedCeiling", async () => {
+            await eventStore.append(new EventType1())
+            const appendCondition: AppendCondition = {
+                query: Query.all(),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await expect(eventStore.append(new EventType1(), appendCondition)).rejects.toThrow(
+                "Expected Version fail: New events matching appendCondition found."
+            )
+        })
+
+        test("should successfully append when prior events are within expectedCeiling", async () => {
+            await eventStore.append(new EventType1())
+            const appendCondition: AppendCondition = {
+                query: Query.all(),
+                expectedCeiling: SequencePosition.create(1)
+            }
+            await eventStore.append(new EventType2(), appendCondition)
+            const events = await streamAllEventsToArray(eventStore.read(Query.all()))
+            expect(events.length).toBe(2)
+        })
+    })
+
+    describe("when append condition uses tag-only query (no eventTypes)", () => {
+        test("should successfully append when no prior events match the tag filter", async () => {
+            const appendCondition: AppendCondition = {
+                query: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)
+            const events = await streamAllEventsToArray(eventStore.read(Query.all()))
+            expect(events.length).toBe(1)
+        })
+
+        test("should reject append when prior events with matching tags exceed expectedCeiling", async () => {
+            await eventStore.append(new EventType1(Tags.from(["some=tag"])))
+            const appendCondition: AppendCondition = {
+                query: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await expect(eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)).rejects.toThrow(
+                "Expected Version fail: New events matching appendCondition found."
+            )
+        })
+
+        test("should successfully append when prior events have different tags", async () => {
+            await eventStore.append(new EventType1(Tags.from(["other=tag"])))
+            const appendCondition: AppendCondition = {
+                query: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)
+            const events = await streamAllEventsToArray(eventStore.read(Query.all()))
+            expect(events.length).toBe(2)
+        })
+
+        test("should successfully append with empty tags in query item", async () => {
+            const appendCondition: AppendCondition = {
+                query: Query.fromItems([{ tags: Tags.createEmpty() }]),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await eventStore.append(new EventType1(), appendCondition)
+            const events = await streamAllEventsToArray(eventStore.read(Query.all()))
+            expect(events.length).toBe(1)
+        })
+
+        test("should successfully append with explicit empty eventTypes array and tags", async () => {
+            const appendCondition: AppendCondition = {
+                query: Query.fromItems([{ eventTypes: [], tags: Tags.from(["some=tag"]) }]),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)
+            const events = await streamAllEventsToArray(eventStore.read(Query.all()))
+            expect(events.length).toBe(1)
+        })
+
+        test("should handle multiple tag-only query items as OR conditions", async () => {
+            await eventStore.append(new EventType1(Tags.from(["tag1=val1"])))
+            const appendCondition: AppendCondition = {
+                query: Query.fromItems([{ tags: Tags.from(["tag1=val1"]) }, { tags: Tags.from(["tag2=val2"]) }]),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await expect(eventStore.append(new EventType1(), appendCondition)).rejects.toThrow(
+                "Expected Version fail: New events matching appendCondition found."
+            )
+        })
+    })
+
+    describe("when append condition uses mixed query items", () => {
+        test("should handle a mix of eventType-only and tag-only query items", async () => {
+            await eventStore.append(new EventType1(Tags.from(["some=tag"])))
+            const appendCondition: AppendCondition = {
+                query: Query.fromItems([{ eventTypes: ["testEvent2"] }, { tags: Tags.from(["some=tag"]) }]),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await expect(eventStore.append(new EventType2(), appendCondition)).rejects.toThrow(
+                "Expected Version fail: New events matching appendCondition found."
+            )
+        })
+
+        test("should succeed when mixed query items find no matching events beyond ceiling", async () => {
+            await eventStore.append(new EventType1(Tags.from(["some=tag"])))
+            const appendCondition: AppendCondition = {
+                query: Query.fromItems([{ eventTypes: ["testEvent2"] }, { tags: Tags.from(["other=tag"]) }]),
+                expectedCeiling: SequencePosition.create(0)
+            }
+            await eventStore.append(new EventType2(), appendCondition)
+            const events = await streamAllEventsToArray(eventStore.read(Query.all()))
+            expect(events.length).toBe(2)
+        })
+    })
+
     test("should throw error if given a transaction that is not at isolation level serializable (READ COMMITTED)", async () => {
         const client = await pool.connect()
         await client.query("BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED")

--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.query.tests.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.query.tests.ts
@@ -27,7 +27,7 @@ class EventType2 implements DcbEvent {
     }
 }
 
-describe("memoryEventStore.query", () => {
+describe("postgresEventStore.query", () => {
     let pool: Pool
     let eventStore: PostgresEventStore
     let client: PoolClient
@@ -151,6 +151,22 @@ describe("memoryEventStore.query", () => {
                 )
                 expect(events.length).toBe(1)
                 expect(events[0].event.tags.equals(Tags.fromObj({ testTagKey: "ev-1" }))).toEqual(true)
+            })
+
+            test("should return matching events when query has tags but no eventTypes property", async () => {
+                const events = await streamAllEventsToArray(
+                    eventStore.read(Query.fromItems([{ tags: Tags.fromObj({ testTagKey: "ev-1" }) }]))
+                )
+                expect(events.length).toBe(1)
+                expect(events[0].event.tags.equals(Tags.fromObj({ testTagKey: "ev-1" }))).toEqual(true)
+            })
+
+            test("should return all matching events across types when filtering by tag only", async () => {
+                const events = await streamAllEventsToArray(
+                    eventStore.read(Query.fromItems([{ tags: Tags.fromObj({ testTagKey: "ev-2" }) }]))
+                )
+                expect(events.length).toBe(1)
+                expect(events[0].event.type).toBe("testEvent2")
             })
         })
     })

--- a/packages/event-store-postgres/src/eventStore/appendCommand.ts
+++ b/packages/event-store-postgres/src/eventStore/appendCommand.ts
@@ -8,7 +8,6 @@ export const appendSql = (
     tableName: string
 ): { statement: string; params: unknown[] } => {
     const params = new ParamManager()
-    const maxSeqNoParam = expectedCeiling ? params.add(expectedCeiling.value) : null
     const formattedEvents = events.map(dbEventConverter.toDb)
 
     // Build VALUES clause for new events
@@ -18,9 +17,9 @@ export const appendSql = (
             e =>
                 //prettier-ignore
                 `(
-                    ${params.add(e.type)}, 
-                    ${params.add(e.data)}::JSONB, 
-                    ${params.add(e.metadata)}::JSONB, 
+                    ${params.add(e.type)},
+                    ${params.add(e.data)}::JSONB,
+                    ${params.add(e.metadata)}::JSONB,
                     ${params.add(e.tags)}::text[]
                 )`
         )
@@ -28,19 +27,35 @@ export const appendSql = (
 
     // Build filtering clause if needed
     const filterClause = (): string => {
-        if (!query || query.isAll) return ""
+        if (!query || !expectedCeiling) return ""
+        const maxSeqNoParam = params.add(expectedCeiling.value)
+
+        if (query.isAll) {
+            return `
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM ${tableName}
+                WHERE sequence_position > ${maxSeqNoParam}::bigint
+            )`
+        }
+
         return `
             WHERE NOT EXISTS (
                 ${query.items
-                    .map(
-                        c => `
+                    .map(c => {
+                        const conditions = [
+                            `tags @> ${params.add(c.tags?.values ?? [])}::text[]`,
+                            `sequence_position > ${maxSeqNoParam}::bigint`
+                        ]
+                        if (c.eventTypes?.length) {
+                            conditions.unshift(`type IN (${c.eventTypes.map(t => params.add(t)).join(", ")})`)
+                        }
+                        return `
                             SELECT 1
                             FROM ${tableName}
-                            WHERE type IN (${(c.eventTypes ?? []).map(t => params.add(t)).join(", ")})
-                            AND tags @> ${params.add(c.tags?.values ?? [])}::text[]
-                            AND sequence_position > ${maxSeqNoParam}::bigint
+                            WHERE ${conditions.join("\n                            AND ")}
                         `
-                    )
+                    })
                     .join(" UNION ALL ")}
             )`
     }


### PR DESCRIPTION
## Summary
- Fixes SQL generation crash when queries contain only tags (no event types) — was generating invalid `WHERE type IN ()`
- Fixes `Query.all()` with `expectedCeiling` causing unresolved `$1` parameter error
- Fixes `Query.all()` silently bypassing optimistic concurrency check (critical correctness bug)

Closes #17

## Test plan
- [x] 13 new tests: Query.all() concurrency, tag-only queries, mixed query items, read path tag filtering
- [x] Core package tests passing (76/76)
- [x] Postgres package compiles cleanly (integration tests require Docker)
- [x] Architect review completed — identified and fixed the Query.all() concurrency bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)