### PR TITLE
fix: exclude test files from build tsconfigs

### DIFF
--- a/examples/course-manager-cli-with-readmodel/tsconfig.json
+++ b/examples/course-manager-cli-with-readmodel/tsconfig.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "outDir": "./dist"
     },
-    "include": ["./src/**/*", "./index.ts"]
+    "include": ["./src/**/*", "./index.ts"],
+    "exclude": ["**/*.tests.ts"]
 }

--- a/examples/course-manager-cli/tsconfig.json
+++ b/examples/course-manager-cli/tsconfig.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "outDir": "./dist"
     },
-    "include": ["./src/**/*", "./index.ts"]
+    "include": ["./src/**/*", "./index.ts"],
+    "exclude": ["**/*.tests.ts"]
 }

--- a/packages/event-store-postgres/tsconfig.json
+++ b/packages/event-store-postgres/tsconfig.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "outDir": "./dist"
     },
-    "include": ["src/**/*", "index.ts"]
+    "include": ["src/**/*", "index.ts"],
+    "exclude": ["**/*.tests.ts"]
 }

--- a/packages/event-store/tsconfig.json
+++ b/packages/event-store/tsconfig.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "outDir": "./dist"
     },
-    "include": ["src/**/*", "index.ts"]
+    "include": ["src/**/*", "index.ts"],
+    "exclude": ["**/*.tests.ts"]
 }


### PR DESCRIPTION
## Summary
- Adds `"exclude": ["**/*.tests.ts"]` to the `tsconfig.json` of all 4 packages/examples
- Fixes `tsc` build failures introduced by the Jest → Vitest migration (PR #22)
- Vitest globals (`describe`, `test`, `expect`) have no type definitions in the build compiler context, causing errors when test files are included in the build

## Test plan
- [ ] `yarn build` passes cleanly across all 4 projects
- [ ] `yarn test` passes all 118 tests (64 unit, 37 postgres, 2 + 15 examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)