### PR TITLE
refactor: align terminology with dcb.events specification

### DIFF
--- a/packages/event-store-postgres/src/eventHandling/HandlerCatchup.ts
+++ b/packages/event-store-postgres/src/eventHandling/HandlerCatchup.ts
@@ -53,13 +53,13 @@ export class HandlerCatchup {
             )
 
             const result = Object.keys(handlers).reduce((acc, handlerId) => {
-                const sequencePosition = selectResult.rows.find(
+                const rawPosition = selectResult.rows.find(
                     row => row.handler_id === handlerId
                 )?.last_sequence_position
-                if (sequencePosition !== undefined) {
+                if (rawPosition !== undefined) {
                     return {
                         ...acc,
-                        [handlerId]: SequencePosition.create(parseInt(sequencePosition))
+                        [handlerId]: SequencePosition.create(parseInt(rawPosition))
                     }
                 } else {
                     throw new Error(`Failed to retrieve sequence number for handler ${handlerId}`)
@@ -83,9 +83,9 @@ export class HandlerCatchup {
             .map((_, index) => `($${index * 2 + 1}::text, $${index * 2 + 2}::bigint)`)
             .join(", ")
 
-        const updateParams = Object.entries(locks).flatMap(([handlerId, sequencePosition]) => [
+        const updateParams = Object.entries(locks).flatMap(([handlerId, position]) => [
             handlerId,
-            sequencePosition.value
+            position.value
         ])
 
         const updateQuery = `
@@ -105,17 +105,17 @@ export class HandlerCatchup {
         if (!toSequencePosition) {
             const lastEventInStore = (await this.eventStore.read(Query.all(), { backwards: true, limit: 1 }).next())
                 .value
-            toSequencePosition = lastEventInStore?.sequencePosition ?? SequencePosition.zero()
+            toSequencePosition = lastEventInStore?.position ?? SequencePosition.zero()
         }
 
-        const query = Query.fromItems([{ eventTypes: Object.keys(handler.when) as string[], tags: Tags.createEmpty() }])
-        for await (const event of this.eventStore.read(query, { fromSequencePosition: currentPosition.inc() })) {
-            if (toSequencePosition && event.sequencePosition.value > toSequencePosition.value) {
+        const query = Query.fromItems([{ types: Object.keys(handler.when) as string[], tags: Tags.createEmpty() }])
+        for await (const event of this.eventStore.read(query, { fromPosition: currentPosition.inc() })) {
+            if (toSequencePosition && event.position.value > toSequencePosition.value) {
                 break
             }
             if (handler.when[event.event.type]) await handler.when[event.event.type](event)
 
-            currentPosition = event.sequencePosition
+            currentPosition = event.position
         }
         return currentPosition
     }

--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.append.tests.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.append.tests.ts
@@ -71,19 +71,19 @@ describe("postgresEventStore.append", () => {
             await eventStore.append(new EventType1())
             const lastSequencePosition = (await streamAllEventsToArray(eventStore.read(Query.all()))).at(
                 -1
-            )?.sequencePosition
+            )?.position
             expect(lastSequencePosition?.value).toBe(1)
         })
-        describe("when append condition with eventTypes filter and expectedCeiling provided", () => {
+        describe("when append condition with types filter and after provided", () => {
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.createEmpty() }]),
-                expectedCeiling: SequencePosition.create(1)
+                failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+                after: SequencePosition.create(1)
             }
             test("should successfully append an event without throwing under specified conditions", async () => {
                 await eventStore.append(new EventType1(), appendCondition)
                 const lastSequencePosition = (await streamAllEventsToArray(eventStore.read(Query.all()))).at(
                     -1
-                )?.sequencePosition
+                )?.position
                 expect(lastSequencePosition?.value).toBe(1)
             })
 
@@ -105,7 +105,7 @@ describe("postgresEventStore.append", () => {
             await eventStore.append(new EventType1())
             const lastSequencePosition = (await streamAllEventsToArray(eventStore.read(Query.all()))).at(
                 -1
-            )?.sequencePosition
+            )?.position
             expect(lastSequencePosition?.value).toBe(2)
         })
 
@@ -113,15 +113,15 @@ describe("postgresEventStore.append", () => {
             await eventStore.append([new EventType1(), new EventType1()])
             const lastSequencePosition = (await streamAllEventsToArray(eventStore.read(Query.all()))).at(
                 -1
-            )?.sequencePosition
+            )?.position
 
             expect(lastSequencePosition?.value).toBe(3)
         })
 
-        describe("when append condition with eventTypes filter and expectedCeiling provided", () => {
+        describe("when append condition with types filter and after provided", () => {
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.createEmpty() }]),
-                expectedCeiling: SequencePosition.zero()
+                failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+                after: SequencePosition.zero()
             }
             test("should throw an error if appended event exceeds the maximum allowed sequence number", async () => {
                 await expect(eventStore.append(new EventType1(), appendCondition)).rejects.toThrow(
@@ -143,8 +143,8 @@ describe("postgresEventStore.append", () => {
                     expect(error).toBeInstanceOf(AppendConditionError)
                     const appendError = error as AppendConditionError
                     expect(appendError.appendCondition).toBe(appendCondition)
-                    expect(appendError.appendCondition.expectedCeiling).toBe(appendCondition.expectedCeiling)
-                    expect(appendError.appendCondition.query).toBe(appendCondition.query)
+                    expect(appendError.appendCondition.after).toBe(appendCondition.after)
+                    expect(appendError.appendCondition.failIfEventsMatch).toBe(appendCondition.failIfEventsMatch)
                 }
             })
 
@@ -173,8 +173,8 @@ describe("postgresEventStore.append", () => {
             const storeEvents = []
 
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: ["testEvent1"] }]),
-                expectedCeiling: SequencePosition.create(1)
+                failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"] }]),
+                after: SequencePosition.create(1)
             }
 
             for (let i = 0; i < 10; i++) {
@@ -206,8 +206,8 @@ describe("postgresEventStore.append", () => {
 
         test("should fail to append next event if append condition is no longer met", async () => {
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.createEmpty() }]),
-                expectedCeiling: SequencePosition.create(1)
+                failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+                after: SequencePosition.create(1)
             }
 
             // First append should pass and set sequence_position to 2
@@ -215,12 +215,12 @@ describe("postgresEventStore.append", () => {
             await eventStore.append(new EventType2())
 
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
-            expect(events.at(-2)?.sequencePosition?.value).toBe(2)
+            expect(events.at(-2)?.position?.value).toBe(2)
 
             // Second append should pass and as its unrelated (different event type)
-            expect(events.at(-1)?.sequencePosition?.value).toBe(3)
+            expect(events.at(-1)?.position?.value).toBe(3)
 
-            // Third append with the same condition should fail because it would exceed expectedCeiling=2
+            // Third append with the same condition should fail because it would exceed after=2
             await expect(eventStore.append(new EventType1(), appendCondition)).rejects.toThrow(
                 AppendConditionError
             )
@@ -230,30 +230,30 @@ describe("postgresEventStore.append", () => {
     describe("when append condition uses Query.all()", () => {
         test("should successfully append when no prior events exist", async () => {
             const appendCondition: AppendCondition = {
-                query: Query.all(),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.all(),
+                after: SequencePosition.create(0)
             }
             await eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
             expect(events.length).toBe(1)
         })
 
-        test("should reject append when prior events exceed expectedCeiling", async () => {
+        test("should reject append when prior events exceed after", async () => {
             await eventStore.append(new EventType1())
             const appendCondition: AppendCondition = {
-                query: Query.all(),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.all(),
+                after: SequencePosition.create(0)
             }
             await expect(eventStore.append(new EventType1(), appendCondition)).rejects.toThrow(
                 "Expected Version fail: New events matching appendCondition found."
             )
         })
 
-        test("should successfully append when prior events are within expectedCeiling", async () => {
+        test("should successfully append when prior events are within after", async () => {
             await eventStore.append(new EventType1())
             const appendCondition: AppendCondition = {
-                query: Query.all(),
-                expectedCeiling: SequencePosition.create(1)
+                failIfEventsMatch: Query.all(),
+                after: SequencePosition.create(1)
             }
             await eventStore.append(new EventType2(), appendCondition)
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
@@ -261,22 +261,22 @@ describe("postgresEventStore.append", () => {
         })
     })
 
-    describe("when append condition uses tag-only query (no eventTypes)", () => {
+    describe("when append condition uses tag-only query (no types)", () => {
         test("should successfully append when no prior events match the tag filter", async () => {
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
+                after: SequencePosition.create(0)
             }
             await eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
             expect(events.length).toBe(1)
         })
 
-        test("should reject append when prior events with matching tags exceed expectedCeiling", async () => {
+        test("should reject append when prior events with matching tags exceed after", async () => {
             await eventStore.append(new EventType1(Tags.from(["some=tag"])))
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
+                after: SequencePosition.create(0)
             }
             await expect(eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)).rejects.toThrow(
                 "Expected Version fail: New events matching appendCondition found."
@@ -286,8 +286,8 @@ describe("postgresEventStore.append", () => {
         test("should successfully append when prior events have different tags", async () => {
             await eventStore.append(new EventType1(Tags.from(["other=tag"])))
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.fromItems([{ tags: Tags.from(["some=tag"]) }]),
+                after: SequencePosition.create(0)
             }
             await eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
@@ -296,18 +296,18 @@ describe("postgresEventStore.append", () => {
 
         test("should successfully append with empty tags in query item", async () => {
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ tags: Tags.createEmpty() }]),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.fromItems([{ tags: Tags.createEmpty() }]),
+                after: SequencePosition.create(0)
             }
             await eventStore.append(new EventType1(), appendCondition)
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
             expect(events.length).toBe(1)
         })
 
-        test("should successfully append with explicit empty eventTypes array and tags", async () => {
+        test("should successfully append with explicit empty types array and tags", async () => {
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: [], tags: Tags.from(["some=tag"]) }]),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.fromItems([{ types: [], tags: Tags.from(["some=tag"]) }]),
+                after: SequencePosition.create(0)
             }
             await eventStore.append(new EventType1(Tags.from(["some=tag"])), appendCondition)
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
@@ -317,8 +317,8 @@ describe("postgresEventStore.append", () => {
         test("should handle multiple tag-only query items as OR conditions", async () => {
             await eventStore.append(new EventType1(Tags.from(["tag1=val1"])))
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ tags: Tags.from(["tag1=val1"]) }, { tags: Tags.from(["tag2=val2"]) }]),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.fromItems([{ tags: Tags.from(["tag1=val1"]) }, { tags: Tags.from(["tag2=val2"]) }]),
+                after: SequencePosition.create(0)
             }
             await expect(eventStore.append(new EventType1(), appendCondition)).rejects.toThrow(
                 "Expected Version fail: New events matching appendCondition found."
@@ -330,8 +330,8 @@ describe("postgresEventStore.append", () => {
         test("should handle a mix of eventType-only and tag-only query items", async () => {
             await eventStore.append(new EventType1(Tags.from(["some=tag"])))
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: ["testEvent2"] }, { tags: Tags.from(["some=tag"]) }]),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.fromItems([{ types: ["testEvent2"] }, { tags: Tags.from(["some=tag"]) }]),
+                after: SequencePosition.create(0)
             }
             await expect(eventStore.append(new EventType2(), appendCondition)).rejects.toThrow(
                 "Expected Version fail: New events matching appendCondition found."
@@ -341,8 +341,8 @@ describe("postgresEventStore.append", () => {
         test("should succeed when mixed query items find no matching events beyond ceiling", async () => {
             await eventStore.append(new EventType1(Tags.from(["some=tag"])))
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: ["testEvent2"] }, { tags: Tags.from(["other=tag"]) }]),
-                expectedCeiling: SequencePosition.create(0)
+                failIfEventsMatch: Query.fromItems([{ types: ["testEvent2"] }, { tags: Tags.from(["other=tag"]) }]),
+                after: SequencePosition.create(0)
             }
             await eventStore.append(new EventType2(), appendCondition)
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))

--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.query.tests.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.query.tests.ts
@@ -88,40 +88,40 @@ describe("postgresEventStore.query", () => {
             await eventStore.append(new EventType2("ev-2"))
         })
 
-        describe("with a fromSequencePosition filter applied", () => {
+        describe("with a fromPosition filter applied", () => {
             test("should return both events when readAll called with no filter", async () => {
                 const events = await streamAllEventsToArray(eventStore.read(Query.all()))
                 expect(events.length).toBe(2)
-                expect(events[0].sequencePosition.value).toBe(1)
-                expect(events[1].sequencePosition.value).toBe(2)
+                expect(events[0].position.value).toBe(1)
+                expect(events[1].position.value).toBe(2)
             })
 
             test("should return both events when readAll called with backwards and no filter", async () => {
                 const events = await streamAllEventsToArray(eventStore.read(Query.all(), { backwards: true }))
                 expect(events.length).toBe(2)
-                expect(events[0].sequencePosition.value).toBe(2)
-                expect(events[1].sequencePosition.value).toBe(1)
+                expect(events[0].position.value).toBe(2)
+                expect(events[1].position.value).toBe(1)
             })
 
             test("should return the second event when read forward from sequence number 2", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.all(), { fromSequencePosition: SequencePosition.create(2) })
+                    eventStore.read(Query.all(), { fromPosition: SequencePosition.create(2) })
                 )
                 expect(events.length).toBe(1)
-                expect(events[0].sequencePosition.value).toBe(2)
+                expect(events[0].position.value).toBe(2)
             })
 
             test("should return the first event when read backward from sequence number 1", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.all(), { fromSequencePosition: SequencePosition.create(1), backwards: true })
+                    eventStore.read(Query.all(), { fromPosition: SequencePosition.create(1), backwards: true })
                 )
                 expect(events.length).toBe(1)
-                expect(events[0].sequencePosition.value).toBe(1)
+                expect(events[0].position.value).toBe(1)
             })
 
             test("should return both first and second event when read backward from sequence number 2", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.all(), { fromSequencePosition: SequencePosition.create(2), backwards: true })
+                    eventStore.read(Query.all(), { fromPosition: SequencePosition.create(2), backwards: true })
                 )
                 expect(events.length).toBe(2)
             })
@@ -130,7 +130,7 @@ describe("postgresEventStore.query", () => {
         describe("when filtered by event types", () => {
             test("should return the event of type 'testEvent1' when read forward with event type filter", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.createEmpty() }]))
+                    eventStore.read(Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]))
                 )
                 expect(events.length).toBe(1)
                 expect(events[0].event.type).toBe("testEvent1")
@@ -140,20 +140,20 @@ describe("postgresEventStore.query", () => {
         describe("when filtered by tags", () => {
             test("should return no events when tag keys do not match", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.fromItems([{ eventTypes: [], tags: Tags.fromObj({ unmatchedId: "ev-1" }) }]))
+                    eventStore.read(Query.fromItems([{ types: [], tags: Tags.fromObj({ unmatchedId: "ev-1" }) }]))
                 )
                 expect(events.length).toBe(0)
             })
 
             test("should return the event matching specific tag key when read forward", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.fromItems([{ eventTypes: [], tags: Tags.fromObj({ testTagKey: "ev-1" }) }]))
+                    eventStore.read(Query.fromItems([{ types: [], tags: Tags.fromObj({ testTagKey: "ev-1" }) }]))
                 )
                 expect(events.length).toBe(1)
                 expect(events[0].event.tags.equals(Tags.fromObj({ testTagKey: "ev-1" }))).toEqual(true)
             })
 
-            test("should return matching events when query has tags but no eventTypes property", async () => {
+            test("should return matching events when query has tags but no types property", async () => {
                 const events = await streamAllEventsToArray(
                     eventStore.read(Query.fromItems([{ tags: Tags.fromObj({ testTagKey: "ev-1" }) }]))
                 )
@@ -180,7 +180,7 @@ describe("postgresEventStore.query", () => {
 
         test("should return two events of type 'testEvent2' when read forward with event type filter", async () => {
             const events = await streamAllEventsToArray(
-                eventStore.read(Query.fromItems([{ eventTypes: ["testEvent2"], tags: Tags.createEmpty() }]))
+                eventStore.read(Query.fromItems([{ types: ["testEvent2"], tags: Tags.createEmpty() }]))
             )
             expect(events.length).toBe(2)
             expect(events[0].event.type).toBe("testEvent2")
@@ -191,8 +191,8 @@ describe("postgresEventStore.query", () => {
             const events = await streamAllEventsToArray(
                 eventStore.read(
                     Query.fromItems([
-                        { eventTypes: ["testEvent2"], tags: Tags.createEmpty() },
-                        { eventTypes: ["testEvent1"], tags: Tags.createEmpty() }
+                        { types: ["testEvent2"], tags: Tags.createEmpty() },
+                        { types: ["testEvent1"], tags: Tags.createEmpty() }
                     ])
                 )
             )
@@ -215,7 +215,7 @@ describe("postgresEventStore.query", () => {
 
         test("should return respect limit clause when read forward", async () => {
             const events = await streamAllEventsToArray(
-                eventStore.read(Query.fromItems([{ eventTypes: ["testEvent2"], tags: Tags.createEmpty() }]), {
+                eventStore.read(Query.fromItems([{ types: ["testEvent2"], tags: Tags.createEmpty() }]), {
                     limit: 1
                 })
             )
@@ -227,7 +227,7 @@ describe("postgresEventStore.query", () => {
 
         test("should return respect limit clause when read backward", async () => {
             const events = await streamAllEventsToArray(
-                eventStore.read(Query.fromItems([{ eventTypes: ["testEvent2"], tags: Tags.createEmpty() }]), {
+                eventStore.read(Query.fromItems([{ types: ["testEvent2"], tags: Tags.createEmpty() }]), {
                     limit: 1,
                     backwards: true
                 })
@@ -242,7 +242,7 @@ describe("postgresEventStore.query", () => {
                 eventStore.read(
                     Query.fromItems([
                         {
-                            eventTypes: ["testEvent1", "testEvent2", "testEvent2"],
+                            types: ["testEvent1", "testEvent2", "testEvent2"],
                             tags: Tags.from(["testTagKey=ev-1", "testTagKey=ev-2"])
                         }
                     ])

--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.ts
@@ -7,7 +7,7 @@ import {
     DcbEvent,
     AppendCondition,
     AppendConditionError,
-    EventEnvelope,
+    SequencedEvent,
     ReadOptions,
     Query
 } from "@dcb-es/event-store"
@@ -38,8 +38,8 @@ export class PostgresEventStore implements EventStore {
             )
 
         const evts = Array.isArray(events) ? events : [events]
-        const { query, expectedCeiling } = appendCondition ?? {}
-        const { statement, params } = appendCommand(evts, query, expectedCeiling, this.tableName)
+        const { failIfEventsMatch, after } = appendCondition ?? {}
+        const { statement, params } = appendCommand(evts, failIfEventsMatch, after, this.tableName)
         const result = await this.client.query(statement, params)
         if (result.rowCount === 0) {
             if (appendCondition) throw new AppendConditionError(appendCondition)
@@ -47,7 +47,7 @@ export class PostgresEventStore implements EventStore {
         }
     }
 
-    async *read(query: Query, options?: ReadOptions): AsyncGenerator<EventEnvelope> {
+    async *read(query: Query, options?: ReadOptions): AsyncGenerator<SequencedEvent> {
         yield* this.readInternal({ query, options })
     }
 
@@ -57,7 +57,7 @@ export class PostgresEventStore implements EventStore {
     }: {
         query: Query
         options?: ReadOptions
-    }): AsyncGenerator<EventEnvelope> {
+    }): AsyncGenerator<SequencedEvent> {
         const { sql, params, cursorName } = readSqlWithCursor(query, this.tableName, options)
         await this.client.query(sql, params)
 

--- a/packages/event-store-postgres/src/eventStore/appendCommand.ts
+++ b/packages/event-store-postgres/src/eventStore/appendCommand.ts
@@ -3,8 +3,8 @@ import { ParamManager, dbEventConverter } from "./utils"
 
 export const appendSql = (
     events: DcbEvent[],
-    query: Query | undefined,
-    expectedCeiling: SequencePosition | undefined,
+    failIfEventsMatch: Query | undefined,
+    after: SequencePosition | undefined,
     tableName: string
 ): { statement: string; params: unknown[] } => {
     const params = new ParamManager()
@@ -27,10 +27,10 @@ export const appendSql = (
 
     // Build filtering clause if needed
     const filterClause = (): string => {
-        if (!query || !expectedCeiling) return ""
-        const maxSeqNoParam = params.add(expectedCeiling.value)
+        if (!failIfEventsMatch || !after) return ""
+        const maxSeqNoParam = params.add(after.value)
 
-        if (query.isAll) {
+        if (failIfEventsMatch.isAll) {
             return `
             WHERE NOT EXISTS (
                 SELECT 1
@@ -41,14 +41,14 @@ export const appendSql = (
 
         return `
             WHERE NOT EXISTS (
-                ${query.items
+                ${failIfEventsMatch.items
                     .map(c => {
                         const conditions = [
                             `tags @> ${params.add(c.tags?.values ?? [])}::text[]`,
                             `sequence_position > ${maxSeqNoParam}::bigint`
                         ]
-                        if (c.eventTypes?.length) {
-                            conditions.unshift(`type IN (${c.eventTypes.map(t => params.add(t)).join(", ")})`)
+                        if (c.types?.length) {
+                            conditions.unshift(`type IN (${c.types.map(t => params.add(t)).join(", ")})`)
                         }
                         return `
                             SELECT 1

--- a/packages/event-store-postgres/src/eventStore/readSql.ts
+++ b/packages/event-store-postgres/src/eventStore/readSql.ts
@@ -37,14 +37,14 @@ const tagFilterSnip = (pm: ParamManager, c: QueryItem): string =>
     c.tags && c.tags.length ? `tags && ${pm.add(c.tags.values)}::text[]` : ""
 
 const fromSeqNoFilter = (pm: ParamManager, tableAlias: string, options?: ReadOptions): string =>
-    options?.fromSequencePosition
+    options?.fromPosition
         ? `${tableAlias ? `${tableAlias}.` : ""}sequence_position ${
               options.backwards ? "<=" : ">="
-          } ${pm.add(options.fromSequencePosition.value)}`
+          } ${pm.add(options.fromPosition.value)}`
         : ""
 
 const typesFilter = (c: QueryItem, pm: ParamManager): string =>
-    c.eventTypes?.length ? `type IN (${c.eventTypes.map(t => pm.add(t)).join(", ")})` : ""
+    c.types?.length ? `type IN (${c.types.map(t => pm.add(t)).join(", ")})` : ""
 
 const getFilterString = (c: QueryItem, pm: ParamManager, options?: ReadOptions): string => {
     const filters = [typesFilter(c, pm), tagFilterSnip(pm, c), fromSeqNoFilter(pm, "", options)]

--- a/packages/event-store-postgres/src/eventStore/utils.ts
+++ b/packages/event-store-postgres/src/eventStore/utils.ts
@@ -1,4 +1,4 @@
-import { Tags, DcbEvent, EventEnvelope, SequencePosition, Timestamp } from "@dcb-es/event-store"
+import { Tags, DcbEvent, SequencedEvent, SequencePosition, Timestamp } from "@dcb-es/event-store"
 
 export type DbWriteEvent = {
     type: string
@@ -23,8 +23,8 @@ export const dbEventConverter = {
         metadata: JSON.stringify(dcbEvent.metadata),
         tags: [...dcbEvent.tags.values]
     }),
-    fromDb: (dbEvent: DbReadEvent): EventEnvelope => ({
-        sequencePosition: SequencePosition.create(parseInt(dbEvent.sequence_position)),
+    fromDb: (dbEvent: DbReadEvent): SequencedEvent => ({
+        position: SequencePosition.create(parseInt(dbEvent.sequence_position)),
         timestamp: Timestamp.create(dbEvent.timestamp),
         event: {
             type: dbEvent.type,

--- a/packages/event-store/index.ts
+++ b/packages/event-store/index.ts
@@ -1,4 +1,4 @@
-export { EventStore, DcbEvent, EventEnvelope, AppendCondition, ReadOptions } from "./src/eventStore/EventStore"
+export { EventStore, DcbEvent, SequencedEvent, AppendCondition, ReadOptions } from "./src/eventStore/EventStore"
 export { AppendConditionError } from "./src/eventStore/AppendConditionError"
 
 export { Query, QueryItem } from "./src/eventStore/Query"

--- a/packages/event-store/src/eventHandling/EventHandler.ts
+++ b/packages/event-store/src/eventHandling/EventHandler.ts
@@ -1,4 +1,4 @@
-import { DcbEvent, EventEnvelope } from "../eventStore/EventStore"
+import { DcbEvent, SequencedEvent } from "../eventStore/EventStore"
 import { Tags } from "../eventStore/Tags"
 
 export interface EventHandler<TEvents extends DcbEvent<string, Tags, unknown, unknown>, TTags extends Tags = Tags> {
@@ -6,7 +6,7 @@ export interface EventHandler<TEvents extends DcbEvent<string, Tags, unknown, un
     onlyLastEvent?: boolean
     when: {
         [E in TEvents as E["type"]]: (
-            eventEnvelope: EventEnvelope<Extract<TEvents, { type: E["type"] }>>
+            sequencedEvent: SequencedEvent<Extract<TEvents, { type: E["type"] }>>
         ) => void | Promise<void>
     }
 }

--- a/packages/event-store/src/eventHandling/EventHandlerWithState.ts
+++ b/packages/event-store/src/eventHandling/EventHandlerWithState.ts
@@ -1,4 +1,4 @@
-import { DcbEvent, EventEnvelope } from "../eventStore/EventStore"
+import { DcbEvent, SequencedEvent } from "../eventStore/EventStore"
 import { Tags } from "../eventStore/Tags"
 
 export interface EventHandlerWithState<
@@ -11,7 +11,7 @@ export interface EventHandlerWithState<
     init: TState
     when: {
         [E in TEvents as E["type"]]: (
-            eventEnvelope: EventEnvelope<Extract<TEvents, { type: E["type"] }>>,
+            sequencedEvent: SequencedEvent<Extract<TEvents, { type: E["type"] }>>,
             state: TState
         ) => TState | Promise<TState>
     }

--- a/packages/event-store/src/eventHandling/buildDecisionModel.tests.ts
+++ b/packages/event-store/src/eventHandling/buildDecisionModel.tests.ts
@@ -33,17 +33,17 @@ describe("buildDecisionModel", () => {
             })
 
             test("should set the maximum sequence number to 0 in appendCondition", async () => {
-                expect(appendCondition?.expectedCeiling.value).toBe(0)
+                expect(appendCondition?.after.value).toBe(0)
             })
 
-            test("should have a single eventType of 'courseWasRegistered' in appendCondition", async () => {
-                const { eventTypes } = <QueryItem>appendCondition.query.items[0]
-                expect(eventTypes?.length).toBe(1)
-                expect(eventTypes?.[0]).toBe("courseWasRegistered")
+            test("should have a single event type of 'courseWasRegistered' in appendCondition", async () => {
+                const { types } = <QueryItem>appendCondition.failIfEventsMatch.items[0]
+                expect(types?.length).toBe(1)
+                expect(types?.[0]).toBe("courseWasRegistered")
             })
 
             test("should include 'courseId' as a tag in appendCondition", async () => {
-                const { tags } = <QueryItem>appendCondition.query.items[0]
+                const { tags } = <QueryItem>appendCondition.failIfEventsMatch.items[0]
                 expect(Object.keys(tags ?? {}).length).toBe(1)
                 expect(tags?.equals(Tags.fromObj({ courseId: "course-1" }))).toEqual(true)
             })
@@ -72,17 +72,17 @@ describe("buildDecisionModel", () => {
         })
 
         test("should set the maximum sequence number to 1 in appendCondition", async () => {
-            expect(appendCondition?.expectedCeiling.value).toBe(1)
+            expect(appendCondition?.after.value).toBe(1)
         })
 
-        test("should have a single eventType of 'courseWasRegistered' in appendCondition", async () => {
-            const { eventTypes } = <QueryItem>appendCondition.query.items[0]
-            expect(eventTypes?.length).toBe(1)
-            expect(eventTypes?.[0]).toBe("courseWasRegistered")
+        test("should have a single event type of 'courseWasRegistered' in appendCondition", async () => {
+            const { types } = <QueryItem>appendCondition.failIfEventsMatch.items[0]
+            expect(types?.length).toBe(1)
+            expect(types?.[0]).toBe("courseWasRegistered")
         })
 
         test("should include 'courseId' as a tag in appendCondition", async () => {
-            const { tags } = <QueryItem>appendCondition.query.items[0]
+            const { tags } = <QueryItem>appendCondition.failIfEventsMatch.items[0]
             expect(Object.keys(tags ?? {}).length).toBe(1)
             expect(tags?.equals(Tags.fromObj({ courseId: "course-1" }))).toEqual(true)
         })
@@ -115,12 +115,12 @@ describe("buildDecisionModel", () => {
         })
 
         test("should set the maximum sequence number to 2 in appendCondition", async () => {
-            expect(appendCondition?.expectedCeiling.value).toBe(2)
+            expect(appendCondition?.after.value).toBe(2)
         })
 
-        test("should have the 4 correct eventTypes in appendCondition", async () => {
-            const { eventTypes } = <QueryItem>appendCondition.query.items[0]
-            expect(eventTypes?.length).toBe(4)
+        test("should have the 4 correct event types in appendCondition", async () => {
+            const { types } = <QueryItem>appendCondition.failIfEventsMatch.items[0]
+            expect(types?.length).toBe(4)
             expect(
                 [
                     "courseWasRegistered",
@@ -128,11 +128,11 @@ describe("buildDecisionModel", () => {
                     "studentWasUnsubscribed",
                     "studentWasSubscribed"
                 ].sort()
-            ).toEqual(expect.arrayContaining((eventTypes ?? []).sort()))
+            ).toEqual(expect.arrayContaining((types ?? []).sort()))
         })
 
         test("should include 'courseId' as a tag in appendCondition", async () => {
-            const { tags } = <QueryItem>appendCondition.query.items[0]
+            const { tags } = <QueryItem>appendCondition.failIfEventsMatch.items[0]
             expect(Object.keys(tags ?? {}).length).toBe(1)
             expect(tags?.equals(Tags.fromObj({ courseId: "course-1" }))).toBe(true)
         })
@@ -168,12 +168,12 @@ describe("buildDecisionModel", () => {
         })
 
         test("should set the maximum sequence number to 2 in appendCondition", async () => {
-            expect(appendCondition?.expectedCeiling.value).toBe(2)
+            expect(appendCondition?.after.value).toBe(2)
         })
 
-        test("should have the 4 correct eventTypes in appendCondition", async () => {
-            const { eventTypes } = <QueryItem>appendCondition.query.items[0]
-            expect(eventTypes?.length).toBe(4)
+        test("should have the 4 correct event types in appendCondition", async () => {
+            const { types } = <QueryItem>appendCondition.failIfEventsMatch.items[0]
+            expect(types?.length).toBe(4)
             expect(
                 [
                     "courseWasRegistered",
@@ -181,11 +181,11 @@ describe("buildDecisionModel", () => {
                     "studentWasUnsubscribed",
                     "studentWasSubscribed"
                 ].sort()
-            ).toEqual(expect.arrayContaining((eventTypes ?? []).sort()))
+            ).toEqual(expect.arrayContaining((types ?? []).sort()))
         })
 
         test("should include 'courseId' as a tag in appendCondition", async () => {
-            const { tags } = <QueryItem>appendCondition.query.items[0]
+            const { tags } = <QueryItem>appendCondition.failIfEventsMatch.items[0]
             expect(Object.keys(tags ?? {}).length).toBe(1)
             expect(tags?.equals(Tags.fromObj({ courseId: "course-1" }))).toEqual(true)
         })

--- a/packages/event-store/src/eventHandling/buildDecisionModel.ts
+++ b/packages/event-store/src/eventHandling/buildDecisionModel.ts
@@ -1,4 +1,4 @@
-import { AppendCondition, EventEnvelope, EventStore } from "../eventStore/EventStore"
+import { AppendCondition, SequencedEvent, EventStore } from "../eventStore/EventStore"
 import { Query, QueryItem } from "../eventStore/Query"
 import { SequencePosition } from "../eventStore/SequencePosition"
 import { Tags } from "../eventStore/Tags"
@@ -15,23 +15,23 @@ export async function buildDecisionModel<T extends EventHandlers>(
     eventStore: EventStore,
     eventHandlers: T
 ): Promise<{ state: EventHandlerStates<T>; appendCondition: AppendCondition }> {
-    const defaultHandler = (_: EventEnvelope, state: EventHandlerStates<T>) => state
+    const defaultHandler = (_: SequencedEvent, state: EventHandlerStates<T>) => state
     const states = Object.fromEntries(Object.entries(eventHandlers).map(([key, value]) => [key, value.init]))
 
     const queryItems: QueryItem[] = Object.values(eventHandlers).map(proj => ({
         tags: proj.tagFilter as Tags,
-        eventTypes: Object.keys(proj.when) as string[]
+        types: Object.keys(proj.when) as string[]
     }))
 
     if (queryItems.length === 0) {
         throw new Error("Event handlers must have at least one event handler")
     }
 
-    const query = Query.fromItems(queryItems)
+    const failIfEventsMatch = Query.fromItems(queryItems)
 
-    let expectedCeiling = SequencePosition.zero()
-    for await (const eventEnvelope of eventStore.read(query)) {
-        const { event, sequencePosition } = eventEnvelope
+    let after = SequencePosition.zero()
+    for await (const sequencedEvent of eventStore.read(failIfEventsMatch)) {
+        const { event, position } = sequencedEvent
 
         for (const [handlerId, eventHandler] of Object.entries(eventHandlers)) {
             const handlerIsRelevant =
@@ -39,10 +39,10 @@ export async function buildDecisionModel<T extends EventHandlers>(
                 matchTags({ tags: event.tags, tagFilter: eventHandler.tagFilter as Tags })
 
             const handler = handlerIsRelevant ? eventHandler.when[event.type] : defaultHandler
-            states[handlerId] = await handler(eventEnvelope, states[handlerId] as EventHandlerStates<T>)
+            states[handlerId] = await handler(sequencedEvent, states[handlerId] as EventHandlerStates<T>)
         }
-        if (sequencePosition > expectedCeiling) expectedCeiling = sequencePosition
+        if (position > after) after = position
     }
 
-    return { state: states as EventHandlerStates<T>, appendCondition: { query, expectedCeiling } }
+    return { state: states as EventHandlerStates<T>, appendCondition: { failIfEventsMatch, after } }
 }

--- a/packages/event-store/src/eventStore/AppendConditionError.tests.ts
+++ b/packages/event-store/src/eventStore/AppendConditionError.tests.ts
@@ -6,8 +6,8 @@ import { Tags } from "./Tags"
 
 describe("AppendConditionError", () => {
     const createAppendCondition = (ceiling: number = 1): AppendCondition => ({
-        query: Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.createEmpty() }]),
-        expectedCeiling: SequencePosition.create(ceiling)
+        failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+        after: SequencePosition.create(ceiling)
     })
 
     test("should be an instance of Error", () => {
@@ -36,16 +36,16 @@ describe("AppendConditionError", () => {
         expect(error.appendCondition).toBe(condition)
     })
 
-    test("should expose the query from the appendCondition", () => {
+    test("should expose failIfEventsMatch from the appendCondition", () => {
         const condition = createAppendCondition()
         const error = new AppendConditionError(condition)
-        expect(error.appendCondition.query).toBe(condition.query)
+        expect(error.appendCondition.failIfEventsMatch).toBe(condition.failIfEventsMatch)
     })
 
-    test("should expose the expectedCeiling from the appendCondition", () => {
+    test("should expose after from the appendCondition", () => {
         const condition = createAppendCondition(5)
         const error = new AppendConditionError(condition)
-        expect(error.appendCondition.expectedCeiling.value).toBe(5)
+        expect(error.appendCondition.after.value).toBe(5)
     })
 
     test("should have a stack trace", () => {
@@ -86,11 +86,11 @@ describe("AppendConditionError", () => {
 
     test("should preserve appendCondition with Query.all()", () => {
         const condition: AppendCondition = {
-            query: Query.all(),
-            expectedCeiling: SequencePosition.create(10)
+            failIfEventsMatch: Query.all(),
+            after: SequencePosition.create(10)
         }
         const error = new AppendConditionError(condition)
-        expect(error.appendCondition.query.isAll).toBe(true)
-        expect(error.appendCondition.expectedCeiling.value).toBe(10)
+        expect(error.appendCondition.failIfEventsMatch.isAll).toBe(true)
+        expect(error.appendCondition.after.value).toBe(10)
     })
 })

--- a/packages/event-store/src/eventStore/EventStore.ts
+++ b/packages/event-store/src/eventStore/EventStore.ts
@@ -10,24 +10,24 @@ export interface DcbEvent<Tpe extends string = string, Tgs = Tags, Dta = unknown
     metadata: Mtdta
 }
 
-export interface EventEnvelope<T extends DcbEvent = DcbEvent> {
+export interface SequencedEvent<T extends DcbEvent = DcbEvent> {
     event: T
     timestamp: Timestamp
-    sequencePosition: SequencePosition
+    position: SequencePosition
 }
 
 export type AppendCondition = {
-    query: Query
-    expectedCeiling: SequencePosition
+    failIfEventsMatch: Query
+    after: SequencePosition
 }
 
 export interface ReadOptions {
     backwards?: boolean
-    fromSequencePosition?: SequencePosition
+    fromPosition?: SequencePosition
     limit?: number
 }
 
 export interface EventStore {
     append: (events: DcbEvent | DcbEvent[], condition?: AppendCondition) => Promise<void>
-    read: (query: Query, options?: ReadOptions) => AsyncGenerator<EventEnvelope>
+    read: (query: Query, options?: ReadOptions) => AsyncGenerator<SequencedEvent>
 }

--- a/packages/event-store/src/eventStore/Query.tests.ts
+++ b/packages/event-store/src/eventStore/Query.tests.ts
@@ -9,10 +9,10 @@ describe("Query", () => {
 
     test("should create query from valid query items using Query.fromItems", () => {
         const items: QueryItem[] = [
-            { eventTypes: ["click"] },
+            { types: ["click"] },
             {
                 tags: Tags.fromObj({ courseId: "c1" }),
-                eventTypes: ["hover"]
+                types: ["hover"]
             }
         ]
         const query = Query.fromItems(items)

--- a/packages/event-store/src/eventStore/Query.ts
+++ b/packages/event-store/src/eventStore/Query.ts
@@ -2,7 +2,7 @@ import { Tags } from "./Tags"
 
 export interface QueryItem {
     tags?: Tags
-    eventTypes?: string[]
+    types?: string[]
 }
 
 export class Query {

--- a/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.append.tests.ts
+++ b/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.append.tests.ts
@@ -32,19 +32,19 @@ describe("memoryEventStore.append", () => {
         test("should assign a sequence number of 1 on appending the first event", async () => {
             await eventStore.append(new EventType1())
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
-            const lastSequencePosition = events.at(-1)?.sequencePosition
+            const lastSequencePosition = events.at(-1)?.position
 
             expect(lastSequencePosition?.value).toBe(1)
         })
-        describe("when append condition with eventTypes filter and maxSequencePosition provided", () => {
+        describe("when append condition with types filter and after provided", () => {
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.createEmpty() }]),
-                expectedCeiling: SequencePosition.create(1)
+                failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+                after: SequencePosition.create(1)
             }
             test("should successfully append an event without throwing under specified conditions", async () => {
                 await eventStore.append(new EventType1(), appendCondition)
                 const events = await streamAllEventsToArray(eventStore.read(Query.all()))
-                const lastSequencePosition = events.at(-1)?.sequencePosition
+                const lastSequencePosition = events.at(-1)?.position
 
                 expect(lastSequencePosition?.value).toBe(1)
             })
@@ -60,7 +60,7 @@ describe("memoryEventStore.append", () => {
         test("should increment sequence number to 2 when a second event is appended", async () => {
             await eventStore.append(new EventType1())
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
-            const lastSequencePosition = events.at(-1)?.sequencePosition
+            const lastSequencePosition = events.at(-1)?.position
 
             expect(lastSequencePosition?.value).toBe(2)
         })
@@ -68,15 +68,15 @@ describe("memoryEventStore.append", () => {
         test("should update the sequence number to 3 after appending two more events", async () => {
             await eventStore.append([new EventType1(), new EventType1()])
             const events = await streamAllEventsToArray(eventStore.read(Query.all()))
-            const lastSequencePosition = events.at(-1)?.sequencePosition
+            const lastSequencePosition = events.at(-1)?.position
 
             expect(lastSequencePosition?.value).toBe(3)
         })
 
-        describe("when append condition with eventTypes filter and maxSequencePosition provided", () => {
+        describe("when append condition with types filter and after provided", () => {
             const appendCondition: AppendCondition = {
-                query: Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.createEmpty() }]),
-                expectedCeiling: SequencePosition.zero()
+                failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+                after: SequencePosition.zero()
             }
             test("should throw an error if appended event exceeds the maximum allowed sequence number", async () => {
                 await expect(eventStore.append(new EventType1(), appendCondition)).rejects.toThrow(
@@ -98,8 +98,8 @@ describe("memoryEventStore.append", () => {
                     expect(error).toBeInstanceOf(AppendConditionError)
                     const appendError = error as AppendConditionError
                     expect(appendError.appendCondition).toBe(appendCondition)
-                    expect(appendError.appendCondition.expectedCeiling).toBe(appendCondition.expectedCeiling)
-                    expect(appendError.appendCondition.query).toBe(appendCondition.query)
+                    expect(appendError.appendCondition.after).toBe(appendCondition.after)
+                    expect(appendError.appendCondition.failIfEventsMatch).toBe(appendCondition.failIfEventsMatch)
                 }
             })
 
@@ -127,8 +127,8 @@ describe("memoryEventStore.append", () => {
         describe("when append condition with tag filter and maxSequencePosition provided", () => {
             test("should throw AppendConditionError when tag-filtered events exist beyond ceiling", async () => {
                 const appendCondition: AppendCondition = {
-                    query: Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.fromObj({ testTagKey: "tagA" }) }]),
-                    expectedCeiling: SequencePosition.zero()
+                    failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.fromObj({ testTagKey: "tagA" }) }]),
+                    after: SequencePosition.zero()
                 }
 
                 await eventStore.append(new EventType1("tagA"))
@@ -140,8 +140,8 @@ describe("memoryEventStore.append", () => {
 
             test("should not throw when tag-filtered events do not match", async () => {
                 const appendCondition: AppendCondition = {
-                    query: Query.fromItems([{ eventTypes: ["testEvent1"], tags: Tags.fromObj({ testTagKey: "tagB" }) }]),
-                    expectedCeiling: SequencePosition.zero()
+                    failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.fromObj({ testTagKey: "tagB" }) }]),
+                    after: SequencePosition.zero()
                 }
 
                 await eventStore.append(new EventType1("tagA"))

--- a/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.query.tests.ts
+++ b/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.query.tests.ts
@@ -72,26 +72,26 @@ describe("memoryEventStore.query", () => {
             await eventStore.append(new EventType2("tag-key-2"))
         })
 
-        describe("with a fromSequencePosition filter applied", () => {
+        describe("with a fromPosition filter applied", () => {
             test("should return the second event when read forward from sequence number 2", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.all(), { fromSequencePosition: SequencePosition.create(2) })
+                    eventStore.read(Query.all(), { fromPosition: SequencePosition.create(2) })
                 )
                 expect(events.length).toBe(1)
-                expect(events[0].sequencePosition.value).toBe(2)
+                expect(events[0].position.value).toBe(2)
             })
 
             test("should return the first event when read backward from sequence number 1", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.all(), { fromSequencePosition: SequencePosition.create(1), backwards: true })
+                    eventStore.read(Query.all(), { fromPosition: SequencePosition.create(1), backwards: true })
                 )
                 expect(events.length).toBe(1)
-                expect(events[0].sequencePosition.value).toBe(1)
+                expect(events[0].position.value).toBe(1)
             })
 
             test("should return both first and second event when read backward from sequence number 2", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.all(), { fromSequencePosition: SequencePosition.create(2), backwards: true })
+                    eventStore.read(Query.all(), { fromPosition: SequencePosition.create(2), backwards: true })
                 )
                 expect(events.length).toBe(2)
             })
@@ -100,7 +100,7 @@ describe("memoryEventStore.query", () => {
         describe("when filtered by event types", () => {
             test("should return the event of type 'testEvent1' when read forward with event type filter", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(Query.fromItems([{ eventTypes: ["testEvent1"] }]))
+                    eventStore.read(Query.fromItems([{ types: ["testEvent1"] }]))
                 )
                 expect(events.length).toBe(1)
                 expect(events[0].event.type).toBe("testEvent1")
@@ -110,18 +110,14 @@ describe("memoryEventStore.query", () => {
         describe("when filtered by tags", () => {
             test("should return no events when tag keys do not match", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(
-                        Query.fromItems([{ eventTypes: [], tags: Tags.fromObj({ unmatchedId: "tag-key-1" }) }])
-                    )
+                    eventStore.read(Query.fromItems([{ types: [], tags: Tags.fromObj({ unmatchedId: "tag-key-1" }) }]))
                 )
                 expect(events.length).toBe(0)
             })
 
             test("should return the event matching specific tag key when read forward", async () => {
                 const events = await streamAllEventsToArray(
-                    eventStore.read(
-                        Query.fromItems([{ eventTypes: [], tags: Tags.fromObj({ testTagKey: "tag-key-1" }) }])
-                    )
+                    eventStore.read(Query.fromItems([{ types: [], tags: Tags.fromObj({ testTagKey: "tag-key-1" }) }]))
                 )
                 expect(events.length).toBe(1)
                 expect(events[0].event.tags.equals(Tags.fromObj({ testTagKey: "tag-key-1" }))).toEqual(true)
@@ -138,9 +134,7 @@ describe("memoryEventStore.query", () => {
         })
 
         test("should return two events of type 'testEvent2' when read forward with event type filter", async () => {
-            const events = await streamAllEventsToArray(
-                eventStore.read(Query.fromItems([{ eventTypes: ["testEvent2"] }]))
-            )
+            const events = await streamAllEventsToArray(eventStore.read(Query.fromItems([{ types: ["testEvent2"] }])))
             expect(events.length).toBe(2)
             expect(events[0].event.type).toBe("testEvent2")
             expect(events[1].event.type).toBe("testEvent2")
@@ -148,7 +142,7 @@ describe("memoryEventStore.query", () => {
 
         test("should treat multiple criteria as OR and return all events when read forward with multiple filters", async () => {
             const events = await streamAllEventsToArray(
-                eventStore.read(Query.fromItems([{ eventTypes: ["testEvent2"] }, { eventTypes: ["testEvent1"] }]))
+                eventStore.read(Query.fromItems([{ types: ["testEvent2"] }, { types: ["testEvent1"] }]))
             )
             expect(events.length).toBe(3)
         })
@@ -162,7 +156,7 @@ describe("memoryEventStore.query", () => {
 
         test("should return respect limit clause when read forward", async () => {
             const events = await streamAllEventsToArray(
-                eventStore.read(Query.fromItems([{ eventTypes: ["testEvent2"] }]), { limit: 1 })
+                eventStore.read(Query.fromItems([{ types: ["testEvent2"] }]), { limit: 1 })
             )
             expect(events.length).toBe(1)
             expect(events[0].event.type).toBe("testEvent2")
@@ -172,7 +166,7 @@ describe("memoryEventStore.query", () => {
 
         test("should return respect limit clause when read backward", async () => {
             const events = await streamAllEventsToArray(
-                eventStore.read(Query.fromItems([{ eventTypes: ["testEvent2"] }]), { limit: 1, backwards: true })
+                eventStore.read(Query.fromItems([{ types: ["testEvent2"] }]), { limit: 1, backwards: true })
             )
             expect(events.length).toBe(1)
             expect(events[0].event.type).toBe("testEvent2")
@@ -184,7 +178,7 @@ describe("memoryEventStore.query", () => {
             eventStore.on("read", () => readCount++)
 
             await streamAllEventsToArray(
-                eventStore.read(Query.fromItems([{ eventTypes: ["testEvent2"] }]), { limit: 1, backwards: true })
+                eventStore.read(Query.fromItems([{ types: ["testEvent2"] }]), { limit: 1, backwards: true })
             )
             expect(readCount).toBe(1)
         })

--- a/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.ts
+++ b/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.ts
@@ -1,4 +1,4 @@
-import { EventEnvelope, EventStore, AppendCondition, DcbEvent, ReadOptions } from "../EventStore"
+import { SequencedEvent, EventStore, AppendCondition, DcbEvent, ReadOptions } from "../EventStore"
 import { AppendConditionError } from "../AppendConditionError"
 import { SequencePosition } from "../SequencePosition"
 import { Timestamp } from "../Timestamp"
@@ -7,9 +7,9 @@ import { Query } from "../Query"
 
 export const ensureIsArray = (events: DcbEvent | DcbEvent[]) => (Array.isArray(events) ? events : [events])
 
-const maxSeqNo = (events: EventEnvelope[]) =>
+const maxSeqNo = (events: SequencedEvent[]) =>
     events
-        .map(event => event.sequencePosition)
+        .map(event => event.position)
         .filter(seqNum => seqNum !== undefined)
         .pop() || SequencePosition.zero()
 
@@ -19,9 +19,9 @@ export class MemoryEventStore implements EventStore {
         append: () => null
     }
 
-    private events: Array<EventEnvelope> = []
+    private events: Array<SequencedEvent> = []
 
-    constructor(initialEvents: Array<EventEnvelope> = []) {
+    constructor(initialEvents: Array<SequencedEvent> = []) {
         this.events = [...initialEvents]
     }
 
@@ -29,16 +29,16 @@ export class MemoryEventStore implements EventStore {
         this.testListenerRegistry[ev] = fn
     }
 
-    async *read(query: Query, options?: ReadOptions): AsyncGenerator<EventEnvelope> {
+    async *read(query: Query, options?: ReadOptions): AsyncGenerator<SequencedEvent> {
         yield* this.#read({ query, options })
     }
-    async *#read({ query, options }: { query: Query; options?: ReadOptions }): AsyncGenerator<EventEnvelope> {
+    async *#read({ query, options }: { query: Query; options?: ReadOptions }): AsyncGenerator<SequencedEvent> {
         if (this.testListenerRegistry.read) this.testListenerRegistry.read()
 
         const step = options?.backwards ? -1 : 1
-        const maxSequencePosition = maxSeqNo(this.events)
-        const defaultSequencePosition = options?.backwards ? maxSequencePosition : SequencePosition.zero()
-        let currentSequencePosition = options?.fromSequencePosition ?? defaultSequencePosition
+        const maxPosition = maxSeqNo(this.events)
+        const defaultPosition = options?.backwards ? maxPosition : SequencePosition.zero()
+        let currentPosition = options?.fromPosition ?? defaultPosition
         let yieldedCount = 0
 
         const allMatchedEvents = !query.isAll
@@ -46,24 +46,20 @@ export class MemoryEventStore implements EventStore {
                   const matchedEvents = this.events
                       .filter(
                           event =>
-                              !isSeqOutOfRange(event.sequencePosition, currentSequencePosition, options?.backwards) &&
+                              !isSeqOutOfRange(event.position, currentPosition, options?.backwards) &&
                               matchesQueryItem(criterion, event)
                       )
                       .map(event => ({ ...event, matchedCriteria: [index.toString()] }))
-                      .sort((a, b) => a.sequencePosition.value - b.sequencePosition.value)
+                      .sort((a, b) => a.position.value - b.position.value)
 
                   return matchedEvents
               })
-            : this.events.filter(
-                  ev => !isSeqOutOfRange(ev.sequencePosition, currentSequencePosition, options?.backwards)
-              )
+            : this.events.filter(ev => !isSeqOutOfRange(ev.position, currentPosition, options?.backwards))
 
         const uniqueEvents = deduplicateEvents(allMatchedEvents)
-            .sort((a, b) => a.sequencePosition.value - b.sequencePosition.value)
+            .sort((a, b) => a.position.value - b.position.value)
             .sort((a, b) =>
-                options?.backwards
-                    ? b.sequencePosition.value - a.sequencePosition.value
-                    : a.sequencePosition.value - b.sequencePosition.value
+                options?.backwards ? b.position.value - a.position.value : a.position.value - b.position.value
             )
 
         for (const event of uniqueEvents) {
@@ -72,38 +68,37 @@ export class MemoryEventStore implements EventStore {
             if (options?.limit && yieldedCount >= options.limit) {
                 break
             }
-            currentSequencePosition = event.sequencePosition.plus(step)
+            currentPosition = event.position.plus(step)
         }
     }
 
     async append(events: DcbEvent | DcbEvent[], appendCondition?: AppendCondition): Promise<void> {
         if (this.testListenerRegistry.append) this.testListenerRegistry.append()
-        const nextSequencePosisition = maxSeqNo(this.events).inc()
-        const eventEnvelopes: Array<EventEnvelope> = ensureIsArray(events).map((ev, i) => ({
+        const nextPosition = maxSeqNo(this.events).inc()
+        const sequencedEvents: Array<SequencedEvent> = ensureIsArray(events).map((ev, i) => ({
             event: ev,
             timestamp: Timestamp.now(),
-            sequencePosition: nextSequencePosisition.plus(i)
+            position: nextPosition.plus(i)
         }))
 
         if (appendCondition) {
-            const { query, expectedCeiling: maxSequencePosition } = appendCondition
+            const { failIfEventsMatch, after } = appendCondition
 
-            const matchingEvents = getMatchingEvents(query, maxSequencePosition, this.events)
+            const matchingEvents = getMatchingEvents(failIfEventsMatch, after, this.events)
 
             if (matchingEvents.length > 0) throw new AppendConditionError(appendCondition)
         }
 
-        this.events.push(...eventEnvelopes)
+        this.events.push(...sequencedEvents)
     }
 }
 
-const getMatchingEvents = (query: Query, maxSeqNo: SequencePosition, events: EventEnvelope[]) => {
-    if (query.isAll) return events.filter(event => !isSeqOutOfRange(event.sequencePosition, maxSeqNo.plus(1), false))
+const getMatchingEvents = (query: Query, maxSeqNo: SequencePosition, events: SequencedEvent[]) => {
+    if (query.isAll) return events.filter(event => !isSeqOutOfRange(event.position, maxSeqNo.plus(1), false))
 
     return (query ?? []).items.flatMap(queryItem =>
         events.filter(
-            event =>
-                !isSeqOutOfRange(event.sequencePosition, maxSeqNo.plus(1), false) && matchesQueryItem(queryItem, event)
+            event => !isSeqOutOfRange(event.position, maxSeqNo.plus(1), false) && matchesQueryItem(queryItem, event)
         )
     )
 }

--- a/packages/event-store/src/eventStore/memoryEventStore/utils.ts
+++ b/packages/event-store/src/eventStore/memoryEventStore/utils.ts
@@ -1,30 +1,28 @@
-import { EventEnvelope } from "../EventStore"
+import { SequencedEvent } from "../EventStore"
 import { SequencePosition } from "../SequencePosition"
 import { matchTags } from "../../eventHandling/matchTags"
 import { QueryItem } from "../Query"
 
 export const isSeqOutOfRange = (
     sequencePosition: SequencePosition,
-    fromSequencePosition: SequencePosition,
+    fromPosition: SequencePosition,
     backwards: boolean | undefined
-) => (backwards ? sequencePosition > fromSequencePosition : sequencePosition < fromSequencePosition)
+) => (backwards ? sequencePosition > fromPosition : sequencePosition < fromPosition)
 
-export const deduplicateEvents = (events: EventEnvelope[]): EventEnvelope[] => {
-    const uniqueEventsMap = new Map<number, EventEnvelope>()
+export const deduplicateEvents = (events: SequencedEvent[]): SequencedEvent[] => {
+    const uniqueEventsMap = new Map<number, SequencedEvent>()
 
     for (const event of events) {
-        if (!uniqueEventsMap.has(event.sequencePosition.value)) {
-            uniqueEventsMap.set(event.sequencePosition.value, event)
+        if (!uniqueEventsMap.has(event.position.value)) {
+            uniqueEventsMap.set(event.position.value, event)
         }
     }
 
     return Array.from(uniqueEventsMap.values())
 }
 
-export const matchesQueryItem = (queryItem: QueryItem, { event }: EventEnvelope) => {
-    //query item does not contain relevant event type
-    if (queryItem.eventTypes && queryItem.eventTypes.length > 0 && !queryItem.eventTypes.includes(event.type))
-        return false
+export const matchesQueryItem = (queryItem: QueryItem, { event }: SequencedEvent) => {
+    if (queryItem.types && queryItem.types.length > 0 && !queryItem.types.includes(event.type)) return false
 
     return matchTags({ tagFilter: queryItem.tags, tags: event.tags })
 }

--- a/packages/event-store/src/eventStore/streamAllEventsToArray.ts
+++ b/packages/event-store/src/eventStore/streamAllEventsToArray.ts
@@ -1,7 +1,7 @@
-import { EventEnvelope } from "../eventStore/EventStore"
+import { SequencedEvent } from "../eventStore/EventStore"
 
-export const streamAllEventsToArray = async (generator: AsyncGenerator<EventEnvelope>): Promise<EventEnvelope[]> => {
-    const results: EventEnvelope[] = []
+export const streamAllEventsToArray = async (generator: AsyncGenerator<SequencedEvent>): Promise<SequencedEvent[]> => {
+    const results: SequencedEvent[] = []
     let done: boolean | undefined = false
     while (!done) {
         const next = await generator.next()

--- a/readme.md
+++ b/readme.md
@@ -97,18 +97,18 @@ The core interface implemented by both `MemoryEventStore` and `PostgresEventStor
 ```typescript
 interface EventStore {
     append(events: DcbEvent | DcbEvent[], condition?: AppendCondition): Promise<void>
-    read(query: Query, options?: ReadOptions): AsyncGenerator<EventEnvelope>
+    read(query: Query, options?: ReadOptions): AsyncGenerator<SequencedEvent>
 }
 ```
 
-**`append`** -- Atomically persists one or more events. When an `AppendCondition` is provided, the store fails if any events matching the condition's query exist after the specified `expectedCeiling`. Throws on condition violation.
+**`append`** -- Atomically persists one or more events. When an `AppendCondition` is provided, the store fails if any events matching `failIfEventsMatch` exist after the specified position. Throws on condition violation.
 
-**`read`** -- Returns an async generator of **Sequenced Events** (called `EventEnvelope` here) matching the query, filtered by event type and/or tags.
+**`read`** -- Returns an async generator of `SequencedEvent`s matching the query, filtered by event type and/or tags.
 
 ```typescript
 interface ReadOptions {
     backwards?: boolean                     // Read in reverse order
-    fromSequencePosition?: SequencePosition // Start from this position
+    fromPosition?: SequencePosition         // Start from this position
     limit?: number                          // Max events to return
 }
 ```
@@ -131,30 +131,28 @@ interface DcbEvent<
 }
 ```
 
-### EventEnvelope
+### SequencedEvent
 
-A **Sequenced Event** in DCB terminology -- an event combined with the Sequence Position assigned by the store during append.
+An event combined with the Sequence Position assigned by the store during append.
 
 ```typescript
-interface EventEnvelope<T extends DcbEvent = DcbEvent> {
+interface SequencedEvent<T extends DcbEvent = DcbEvent> {
     event: T
     timestamp: Timestamp
-    sequencePosition: SequencePosition
+    position: SequencePosition
 }
 ```
 
 ### AppendCondition
 
-Enforces consistency via query-based optimistic locking. The store fails the append if any events matching `query` exist after `expectedCeiling`.
+Enforces consistency via query-based optimistic locking. The store fails the append if any events matching `failIfEventsMatch` exist after the given position.
 
 ```typescript
 type AppendCondition = {
-    query: Query                       // The query to check for conflicting events
-    expectedCeiling: SequencePosition  // Ignore events at or before this position
+    failIfEventsMatch: Query           // The query to check for conflicting events
+    after: SequencePosition            // Ignore events at or before this position
 }
 ```
-
-This maps to the DCB spec concept of `failIfEventsMatch` (query) with an `after` position (`expectedCeiling`).
 
 ### Tags
 
@@ -189,15 +187,15 @@ const query = Query.all()
 
 // Filtered query -- items are OR'd together
 const query = Query.fromItems([
-    { eventTypes: ["courseWasRegistered"], tags: Tags.fromObj({ courseId: "math-101" }) },
-    { eventTypes: ["studentWasSubscribed"], tags: Tags.fromObj({ courseId: "math-101" }) }
+    { types: ["courseWasRegistered"], tags: Tags.fromObj({ courseId: "math-101" }) },
+    { types: ["studentWasSubscribed"], tags: Tags.fromObj({ courseId: "math-101" }) }
 ])
 ```
 
 ```typescript
 interface QueryItem {
     tags?: Tags           // Events must include all of these tags (subset match)
-    eventTypes?: string[] // Events must be one of these types
+    types?: string[]      // Events must be one of these types
 }
 ```
 
@@ -243,7 +241,7 @@ interface EventHandlerWithState<TEvents extends DcbEvent, TState, TTags extends 
     onlyLastEvent?: boolean     // Declared in the interface but not currently used by buildDecisionModel
     init: TState                // Initial state before any events
     when: {
-        [EventType]: (eventEnvelope: EventEnvelope, state: TState) => TState | Promise<TState>
+        [EventType]: (sequencedEvent: SequencedEvent, state: TState) => TState | Promise<TState>
     }
 }
 ```
@@ -287,7 +285,7 @@ interface EventHandler<TEvents extends DcbEvent, TTags extends Tags = Tags> {
     tagFilter?: Partial<TTags>
     onlyLastEvent?: boolean  // Declared in the interface but not currently used by HandlerCatchup
     when: {
-        [EventType]: (eventEnvelope: EventEnvelope) => void | Promise<void>
+        [EventType]: (sequencedEvent: SequencedEvent) => void | Promise<void>
     }
 }
 ```
@@ -335,7 +333,7 @@ import { MemoryEventStore } from "@dcb-es/event-store"
 const store = new MemoryEventStore()
 
 // Pre-seed with existing Sequenced Events
-const store = new MemoryEventStore(existingEventEnvelopes)
+const store = new MemoryEventStore(existingSequencedEvents)
 
 // Test helpers: register listeners for read/append calls
 store.on("read", () => readCount++)


### PR DESCRIPTION
## Summary
- Rename `AppendCondition` fields: `query` → `failIfEventsMatch`, `expectedCeiling` → `after`
- Rename `EventEnvelope` → `SequencedEvent`, field `sequencePosition` → `position`
- Rename `QueryItem.eventTypes` → `types`
- Rename `ReadOptions.fromSequencePosition` → `fromPosition`
- Update README API reference throughout
- Also renames applied to new `AppendConditionError` tests from main

No logic changes — pure terminology alignment with the [dcb.events specification](https://dcb.events/specification/).

## Test plan
- [x] Pre-flight passing (build, lint, 131 tests across all packages + examples)
- [x] do-review complete — architect review found no CRITICAL/HIGH/MEDIUM issues

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/claude-code)