### PR TITLE
feat: add multi-agent PR review workflow

### DIFF
--- a/.github/pr-review-agents/README.md
+++ b/.github/pr-review-agents/README.md
@@ -78,7 +78,7 @@ matrix:
 |------|------|---------|
 | `LITELLM_API_KEY` | Secret | Authentication token for LiteLLM proxy |
 | `LITE_LLM_WAF_AUTH_KEY` | Secret | WAF bypass key (`x-ktl-auth-key` header) |
-| `LITELLM_BASE_URL` | Variable | LiteLLM endpoint (set as `ANTHROPIC_BASE_URL`) |
+| `LITELLM_BASE_URL` | Secret | LiteLLM endpoint (set as `ANTHROPIC_BASE_URL`) |
 | `GITHUB_TOKEN` | Secret | Provided automatically by GitHub Actions |
 
 ## Adding a new review agent

--- a/.github/pr-review-agents/README.md
+++ b/.github/pr-review-agents/README.md
@@ -1,0 +1,90 @@
+# Automated PR Review Agents
+
+Multi-agent PR review system using `claude-code-action` in GitHub Actions. Each PR is reviewed in parallel by four independent agents, each with full access to the checked-out repository.
+
+## How it works
+
+```
+PR opened / pushed
+       |
+       v
++---------------------------+
+|  pr-review.yml workflow   |
+|  (matrix: 4 agents)      |
++----+--+--+--+-------------+
+     |  |  |  |
+     v  v  v  v
+   [A][S][B][Q]              Each job runs claude-code-action
+     |  |  |  |              with a different review prompt
+     v  v  v  v
+   LiteLLM proxy             Routes to configured model per agent
+     |  |  |  |
+     v  v  v  v
+   PR comments               Posted as comments on the PR
+```
+
+**A** = Architecture, **S** = Security, **B** = Breaking Changes, **Q** = Code Quality
+
+## Key difference from a simple "send diff to API" approach
+
+Each agent is autonomous — it doesn't just see the diff. It:
+- Reads the full repository (checked out on the runner)
+- Reads `CLAUDE.md` for project conventions automatically
+- Follows imports to understand context around changed code
+- Checks for related test files
+- Decides what additional files to read based on the diff
+- Posts comments on the PR
+
+## File layout
+
+```
+.github/
++-- pr-review-agents/
+|   +-- README.md               <-- You are here
+|   +-- architecture.md         Layer boundaries, dependency direction, DCB patterns
+|   +-- security.md             SQL/DynamoDB injection, input validation, concurrency
+|   +-- breaking-changes.md     API changes, removed exports, type narrowing
+|   +-- code-quality.md         Bugs, duplication, concurrency correctness
++-- workflows/
+    +-- pr-review.yml           PR review workflow
+```
+
+## Agent prompts
+
+Each `.md` file in `pr-review-agents/` defines a review perspective. Prompts are tailored to the DCB event store's architecture — package boundaries, EventStore interface, Tag/Query model, SequencePosition opacity, and adapter separation.
+
+Prompts are version-controlled and PR-able. To tune review focus, edit the relevant markdown file.
+
+## Per-agent model selection
+
+Models are configured per agent in the workflow matrix:
+
+```yaml
+matrix:
+  include:
+    - agent: architecture
+      model: claude-opus-4-6       # Complex, nuanced review
+    - agent: security
+      model: claude-sonnet-4-6     # Faster, pattern-matching
+    - agent: breaking-changes
+      model: claude-sonnet-4-6
+    - agent: code-quality
+      model: claude-sonnet-4-6
+```
+
+## Required secrets and variables
+
+| Name | Type | Purpose |
+|------|------|---------|
+| `LITELLM_API_KEY` | Secret | Authentication token for LiteLLM proxy |
+| `LITELLM_BASE_URL` | Variable | LiteLLM endpoint (set as `ANTHROPIC_BASE_URL`) |
+| `GITHUB_TOKEN` | Secret | Provided automatically by GitHub Actions |
+
+## Adding a new review agent
+
+1. Create `.github/pr-review-agents/<name>.md` with the review prompt
+2. Add an entry to the matrix in `.github/workflows/pr-review.yml`:
+   ```yaml
+   - agent: <name>
+     model: claude-sonnet-4-6
+   ```

--- a/.github/pr-review-agents/README.md
+++ b/.github/pr-review-agents/README.md
@@ -77,6 +77,7 @@ matrix:
 | Name | Type | Purpose |
 |------|------|---------|
 | `LITELLM_API_KEY` | Secret | Authentication token for LiteLLM proxy |
+| `LITE_LLM_WAF_AUTH_KEY` | Secret | WAF bypass key (`x-ktl-auth-key` header) |
 | `LITELLM_BASE_URL` | Variable | LiteLLM endpoint (set as `ANTHROPIC_BASE_URL`) |
 | `GITHUB_TOKEN` | Secret | Provided automatically by GitHub Actions |
 

--- a/.github/pr-review-agents/architecture.md
+++ b/.github/pr-review-agents/architecture.md
@@ -1,0 +1,22 @@
+# Architecture Reviewer
+
+You are reviewing a pull request for architectural consistency in a TypeScript monorepo implementing the Dynamic Consistency Boundary (DCB) event sourcing pattern.
+
+## Focus areas
+
+- **Package boundaries** — `@dcb-es/event-store` is the core abstraction; adapter packages (`event-store-postgres`, `event-store-dynamodb`) depend on it, never the reverse
+- **Dependency direction** — adapters import from core, examples import from packages. No upward or circular imports.
+- **Interface conformance** — adapter implementations must satisfy the `EventStore` interface without extending its contract
+- **Separation of concerns** — command validation (decision models) vs event persistence (store) vs projections (handlers) should stay in distinct layers
+- **Tag/Query model integrity** — changes to `Tag`, `Query`, or `EventInStore` types must not leak adapter-specific concerns into the core
+- **SequencePosition opacity** — `SequencePosition` is opaque; adapters must not assume numeric ordering or expose internal representation
+- **Test infrastructure** — shared test setup (`test/`) should remain adapter-agnostic; adapter-specific test helpers stay in their package
+- **Public API surface** — exports via `src/index.ts`; no deep imports into package internals
+
+## Severity guide
+
+- **critical**: Architectural violation that will cause problems at scale (wrong dependency direction, broken layer boundary, adapter-specific leakage into core)
+- **warning**: Convention deviation or naming inconsistency
+- **suggestion**: Improvement opportunity, not blocking
+
+Include severity in each finding's body.

--- a/.github/pr-review-agents/breaking-changes.md
+++ b/.github/pr-review-agents/breaking-changes.md
@@ -1,0 +1,23 @@
+# Breaking Changes Reviewer
+
+You are reviewing a pull request for breaking changes in a TypeScript event sourcing library published as npm packages.
+
+## Focus areas
+
+- **Removed exports** — types, functions, constants removed from any package's `src/index.ts`
+- **Renamed exports** — symbols renamed without aliasing the old name
+- **Signature changes** — function parameters added (non-optional), removed, or reordered
+- **Type narrowing** — types made more restrictive (e.g., `SequencePosition` becoming opaque, `Tag` type changes)
+- **EventStore interface changes** — modifications to `read`, `append`, or any core interface method
+- **Query/Tag model changes** — changes to how events are queried or tagged that affect existing consumers
+- **Decision model API changes** — changes to `buildDecisionModel` or event handler signatures
+- **Behaviour changes** — same API, different runtime behaviour (e.g., different ordering, different error types)
+- **Package restructuring** — files moved, packages renamed, entry points changed
+
+## Severity guide
+
+- **breaking**: Consumers will fail at compile time or runtime
+- **potentially-breaking**: Behaviour change that may affect consumers depending on usage
+- **safe**: Change is additive or internal only
+
+Include severity in each finding's body. If no breaking changes found, return empty findings.

--- a/.github/pr-review-agents/code-quality.md
+++ b/.github/pr-review-agents/code-quality.md
@@ -1,0 +1,22 @@
+# Code Quality Reviewer
+
+You are reviewing a pull request for code quality issues in a TypeScript event sourcing library.
+
+## Focus areas
+
+- **Bugs and logic errors** — off-by-one in sequence positions, null/undefined access, incorrect conditions, unreachable code
+- **Error handling** — swallowed errors, missing catch blocks, generic catch-all without re-throw, `AppendConditionError` used correctly
+- **Concurrency correctness** — optimistic concurrency checks, lock ordering, fencing token validation, race conditions in async code
+- **Code duplication** — repeated logic across adapters that should be in core, or within a single package
+- **Unnecessary complexity** — over-engineering, premature abstraction, convoluted control flow
+- **Performance** — N+1 query patterns, unnecessary allocations, blocking operations in async code, unbounded batch operations
+- **Dead code** — unused variables, unreachable branches, commented-out code
+- **Type safety** — unnecessary `any` casts, missing type narrowing, unsafe assertions on database results
+
+## Severity guide
+
+- **bug**: Likely runtime error or incorrect behaviour
+- **warning**: Code smell or maintainability concern
+- **suggestion**: Improvement opportunity, not blocking
+
+Include severity in each finding's body. Focus on genuine issues — do not flag style preferences already enforced by ESLint/Prettier.

--- a/.github/pr-review-agents/security.md
+++ b/.github/pr-review-agents/security.md
@@ -1,0 +1,25 @@
+# Security Reviewer
+
+You are reviewing a pull request for security vulnerabilities in a TypeScript event sourcing library.
+
+## Focus areas
+
+- **SQL injection** — parameterised queries in `event-store-postgres`; no string interpolation in SQL
+- **DynamoDB injection** — expression attribute values must be parameterised, never interpolated into condition expressions
+- **Input validation** — event types, tag keys/values, and query parameters must be validated at system boundaries
+- **Hardcoded secrets** — connection strings, API keys, tokens in code or test fixtures (non-local URIs)
+- **Race conditions / TOCTOU** — optimistic concurrency checks must be atomic; gap between read and write must not allow inconsistent state
+- **Unsafe type assertions** — `as any`, `as unknown as T`, or unchecked casts on data from external sources (database rows, user input)
+- **Denial of service** — unbounded queries, missing pagination limits, uncapped batch sizes
+- **Dependency risks** — known vulnerable packages, unnecessary permissions
+
+## Severity ratings
+
+Rate each finding: **CRITICAL** / **HIGH** / **MEDIUM** / **LOW**
+
+- CRITICAL: Exploitable vulnerability, immediate risk
+- HIGH: Security weakness likely to be exploitable
+- MEDIUM: Defence-in-depth concern, not directly exploitable
+- LOW: Best practice deviation, minimal risk
+
+Include the severity rating at the start of each finding's body.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,61 @@
+name: Multi-Agent PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - agent: architecture
+            model: claude-opus-4-6
+          - agent: security
+            model: claude-sonnet-4-6
+          - agent: breaking-changes
+            model: claude-sonnet-4-6
+          - agent: code-quality
+            model: claude-sonnet-4-6
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read agent prompt
+        id: prompt
+        env:
+          AGENT_NAME: ${{ matrix.agent }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo 'PROMPT<<AGENT_PROMPT_DELIM'
+            echo "REPO: $REPO"
+            echo "PR NUMBER: $PR_NUMBER"
+            echo ""
+            cat ".github/pr-review-agents/${AGENT_NAME}.md"
+            echo ""
+            echo "The PR branch is already checked out. Use \`gh pr diff $PR_NUMBER\` to get the diff."
+            echo "Post your findings using \`gh pr comment $PR_NUMBER --body \"<findings>\"\`."
+            echo "Only post GitHub comments — do not submit review text as messages."
+            echo 'AGENT_PROMPT_DELIM'
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.LITELLM_API_KEY }}
+          prompt: ${{ steps.prompt.outputs.PROMPT }}
+          claude_args: "--model ${{ matrix.model }} --allowedTools 'Bash(gh pr diff*),Bash(gh pr comment*),Bash(git diff*),Read,Glob,Grep'"
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_API_KEY }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -57,6 +57,6 @@ jobs:
           prompt: ${{ steps.prompt.outputs.PROMPT }}
           claude_args: "--model ${{ matrix.model }} --allowedTools 'Bash(gh pr diff*),Bash(gh pr comment*),Bash(git diff*),Read,Glob,Grep'"
         env:
-          ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_API_KEY }}
           ANTHROPIC_CUSTOM_HEADERS: "x-ktl-auth-key: ${{ secrets.LITE_LLM_WAF_AUTH_KEY }}"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -59,3 +59,4 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.LITELLM_API_KEY }}
+          ANTHROPIC_CUSTOM_HEADERS: "x-ktl-auth-key: ${{ secrets.LITE_LLM_WAF_AUTH_KEY }}"


### PR DESCRIPTION
## Summary
- Four parallel `claude-code-action` agents review every PR: architecture, security, breaking changes, code quality
- Prompts tailored to DCB event store patterns (package boundaries, SequencePosition opacity, concurrency correctness)
- Routes through LiteLLM proxy — requires `LITELLM_API_KEY` secret and `LITELLM_BASE_URL` variable

## Test plan
- [ ] Pre-flight passing (build, lint, test)
- [ ] Verify workflow triggers on a test PR after secrets are configured
- [ ] Confirm agents post comments on the PR

Closes #53

🤖 Generated with [Claude Code](https://claude.ai/claude-code)