### PR TITLE
refactor!: update examples + enforce types+tags on AppendCondition

### DIFF
--- a/examples/course-manager-cli-with-readmodel/index.ts
+++ b/examples/course-manager-cli-with-readmodel/index.ts
@@ -14,14 +14,14 @@ import { HandlerCatchup, PostgresEventStore } from "@dcb-es/event-store-postgres
     }
 
     const pool = new Pool(postgresConfig)
-    const eventStore = new PostgresEventStore(pool)
+    const eventStore = new PostgresEventStore({ pool })
     await eventStore.ensureInstalled()
 
     const handlerCatchup = new HandlerCatchup(pool, eventStore)
     await handlerCatchup.ensureInstalled(Object.keys(setupHandlers(pool)))
 
     await installPostgresCourseSubscriptionsRepository(pool)
-    const api = new Api(pool)
+    const api = new Api(pool, eventStore, handlerCatchup)
 
     await startCli(api)
 })()

--- a/examples/course-manager-cli-with-readmodel/src/api/Api.tests.ts
+++ b/examples/course-manager-cli-with-readmodel/src/api/Api.tests.ts
@@ -1,4 +1,4 @@
-import { Pool, PoolClient } from "pg"
+import { Pool } from "pg"
 import {
     Course,
     installPostgresCourseSubscriptionsRepository,
@@ -24,32 +24,24 @@ describe("EventSourcedApi", () => {
     let pool: Pool
     let repository: ReturnType<typeof PostgresCourseSubscriptionsRepository>
     let api: Api
-    let client: PoolClient
 
     beforeAll(async () => {
         pool = await getTestPgDatabasePool()
-        const eventStore = new PostgresEventStore(pool)
+        const eventStore = new PostgresEventStore({ pool })
         await eventStore.ensureInstalled()
         await installPostgresCourseSubscriptionsRepository(pool)
-        api = new Api(pool)
-    })
-
-    beforeEach(async () => {
-        client = await pool.connect()
-        const handlerCatchup = new HandlerCatchup(pool, new PostgresEventStore(pool))
-        await handlerCatchup.ensureInstalled(Object.keys(setupHandlers(client)))
-
-        await client.query("BEGIN transaction isolation level serializable")
-        repository = PostgresCourseSubscriptionsRepository(client)
+        const handlerCatchup = new HandlerCatchup(pool, eventStore)
+        await handlerCatchup.ensureInstalled(Object.keys(setupHandlers(pool)))
+        api = new Api(pool, eventStore, handlerCatchup)
+        repository = PostgresCourseSubscriptionsRepository(pool)
     })
 
     afterEach(async () => {
-        client.query("ROLLBACK;")
-        client.release()
         await pool.query("TRUNCATE table events")
         await pool.query("TRUNCATE table courses")
         await pool.query("TRUNCATE table students")
         await pool.query("TRUNCATE table subscriptions")
+        await pool.query("UPDATE _handler_bookmarks SET last_sequence_position = 0")
     })
 
     afterAll(async () => {
@@ -98,7 +90,6 @@ describe("EventSourcedApi", () => {
 
     describe("with one course and 100 students in database", () => {
         beforeEach(async () => {
-            api = new Api(pool)
             await api.registerCourse({ id: COURSE_1.id, title: COURSE_1.title, capacity: COURSE_1.capacity })
 
             for (let i = 0; i < 100; i++) {

--- a/examples/course-manager-cli-with-readmodel/src/api/Api.ts
+++ b/examples/course-manager-cli-with-readmodel/src/api/Api.ts
@@ -1,9 +1,9 @@
-import { buildDecisionModel } from "@dcb-es/event-store"
+import { buildDecisionModel, EventStore } from "@dcb-es/event-store"
 import {
     PostgresCourseSubscriptionsRepository,
     STUDENT_SUBSCRIPTION_LIMIT
 } from "../postgresCourseSubscriptionRepository/PostgresCourseSubscriptionRespository"
-import { Pool, PoolClient } from "pg"
+import { Pool } from "pg"
 import {
     CourseWasRegisteredEvent,
     StudentWasRegistered,
@@ -22,19 +22,26 @@ import {
     StudentAlreadySubscribed,
     StudentSubscriptions
 } from "./DecisionModels"
-import { HandlerCatchup, PostgresEventStore } from "@dcb-es/event-store-postgres"
+import { HandlerCatchup } from "@dcb-es/event-store-postgres"
 import { PostgresCourseSubscriptionsProjection } from "./PostgresCourseSubscriptionsProjection"
 
-export const setupHandlers = (client: PoolClient | Pool) => ({
-    CourseProjection: PostgresCourseSubscriptionsProjection(client)
+export const setupHandlers = (pool: Pool) => ({
+    CourseProjection: PostgresCourseSubscriptionsProjection(pool)
 })
-export class Api {
-    private pool: Pool
-    private readModelRepository: ReturnType<typeof PostgresCourseSubscriptionsRepository>
 
-    constructor(pool: Pool) {
-        this.pool = pool
+export class Api {
+    private readModelRepository: ReturnType<typeof PostgresCourseSubscriptionsRepository>
+    private handlerCatchup: HandlerCatchup
+    private handlers: ReturnType<typeof setupHandlers>
+
+    constructor(
+        pool: Pool,
+        private eventStore: EventStore,
+        handlerCatchup: HandlerCatchup
+    ) {
         this.readModelRepository = PostgresCourseSubscriptionsRepository(pool)
+        this.handlerCatchup = handlerCatchup
+        this.handlers = setupHandlers(pool)
     }
 
     async findCourseById(courseId: string) {
@@ -46,185 +53,113 @@ export class Api {
     }
 
     async registerCourse(cmd: { id: string; title: string; capacity: number }) {
-        const client = await this.pool.connect()
-        await client.query("BEGIN transaction isolation level serializable")
-        try {
-            const eventStore = new PostgresEventStore(client)
-            const { state, appendCondition } = await buildDecisionModel(eventStore, {
-                courseExists: CourseExists(cmd.id)
-            })
+        const { state, appendCondition } = await buildDecisionModel(this.eventStore, {
+            courseExists: CourseExists(cmd.id)
+        })
 
-            if (state.courseExists) throw new Error(`Course with id ${cmd.id} already exists`)
-            await eventStore.append(
-                new CourseWasRegisteredEvent({ courseId: cmd.id, title: cmd.title, capacity: cmd.capacity }),
-                appendCondition
-            )
+        if (state.courseExists) throw new Error(`Course with id ${cmd.id} already exists`)
 
-            const handlerCatchup = new HandlerCatchup(client, eventStore)
-            await handlerCatchup.catchupHandlers(setupHandlers(client))
-            await client.query("COMMIT")
-        } catch (err) {
-            await client.query("ROLLBACK")
-            throw err
-        } finally {
-            client.release()
-        }
+        await this.eventStore.append({
+            events: new CourseWasRegisteredEvent({ courseId: cmd.id, title: cmd.title, capacity: cmd.capacity }),
+            condition: appendCondition
+        })
+        await this.handlerCatchup.catchupHandlers(this.handlers)
     }
 
     async registerStudent(cmd: { id: string; name: string }) {
         const { id, name } = cmd
-        const client = await this.pool.connect()
-        await client.query("BEGIN transaction isolation level serializable")
-        try {
-            const eventStore = new PostgresEventStore(client)
-            const { state, appendCondition } = await buildDecisionModel(eventStore, {
-                studentAlreadyRegistered: StudentAlreadyRegistered(id),
-                nextStudentNumber: NextStudentNumber()
-            })
+        const { state, appendCondition } = await buildDecisionModel(this.eventStore, {
+            studentAlreadyRegistered: StudentAlreadyRegistered(id),
+            nextStudentNumber: NextStudentNumber()
+        })
 
-            if (state.studentAlreadyRegistered) throw new Error(`Student with id ${id} already registered.`)
-            await eventStore.append(
-                new StudentWasRegistered({ studentId: id, name: name, studentNumber: state.nextStudentNumber }),
-                appendCondition
-            )
+        if (state.studentAlreadyRegistered) throw new Error(`Student with id ${id} already registered.`)
 
-            const handlerCatchup = new HandlerCatchup(client, eventStore)
-            await handlerCatchup.catchupHandlers(setupHandlers(client))
-            await client.query("COMMIT")
-        } catch (err) {
-            await client.query("ROLLBACK")
-            throw err
-        } finally {
-            client.release()
-        }
+        await this.eventStore.append({
+            events: new StudentWasRegistered({ studentId: id, name, studentNumber: state.nextStudentNumber }),
+            condition: appendCondition
+        })
+        await this.handlerCatchup.catchupHandlers(this.handlers)
     }
 
     async updateCourseCapacity(cmd: { courseId: string; newCapacity: number }) {
         const { courseId, newCapacity } = cmd
-        const client = await this.pool.connect()
-        await client.query("BEGIN transaction isolation level serializable")
-        try {
-            const eventStore = new PostgresEventStore(client)
 
-            const { state, appendCondition } = await buildDecisionModel(eventStore, {
-                courseExists: CourseExists(courseId),
-                CourseCapacity: CourseCapacity(courseId)
-            })
+        const { state, appendCondition } = await buildDecisionModel(this.eventStore, {
+            courseExists: CourseExists(courseId),
+            CourseCapacity: CourseCapacity(courseId)
+        })
 
-            if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
-            if (state.CourseCapacity.capacity === newCapacity)
-                throw new Error("New capacity is the same as the current capacity.")
+        if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
+        if (state.CourseCapacity.capacity === newCapacity)
+            throw new Error("New capacity is the same as the current capacity.")
 
-            await eventStore.append(new CourseCapacityWasChangedEvent({ courseId, newCapacity }), appendCondition)
-
-            const handlerCatchup = new HandlerCatchup(client, eventStore)
-            await handlerCatchup.catchupHandlers(setupHandlers(client))
-            await client.query("COMMIT")
-        } catch (err) {
-            await client.query("ROLLBACK")
-            throw err
-        } finally {
-            client.release()
-        }
+        await this.eventStore.append({
+            events: new CourseCapacityWasChangedEvent({ courseId, newCapacity }),
+            condition: appendCondition
+        })
+        await this.handlerCatchup.catchupHandlers(this.handlers)
     }
 
     async updateCourseTitle(cmd: { courseId: string; newTitle: string }) {
         const { courseId, newTitle } = cmd
-        const client = await this.pool.connect()
-        await client.query("BEGIN transaction isolation level serializable")
-        try {
-            const eventStore = new PostgresEventStore(client)
 
-            const { state, appendCondition } = await buildDecisionModel(eventStore, {
-                courseExists: CourseExists(courseId),
-                courseTitle: CourseTitle(courseId)
-            })
+        const { state, appendCondition } = await buildDecisionModel(this.eventStore, {
+            courseExists: CourseExists(courseId),
+            courseTitle: CourseTitle(courseId)
+        })
 
-            if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
-            if (state.courseTitle === newTitle) throw new Error("New title is the same as the current title.")
-            await eventStore.append(new CourseTitleWasChangedEvent({ courseId, newTitle }), appendCondition)
+        if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
+        if (state.courseTitle === newTitle) throw new Error("New title is the same as the current title.")
 
-            const handlerCatchup = new HandlerCatchup(client, eventStore)
-            await handlerCatchup.catchupHandlers(setupHandlers(client))
-            await client.query("COMMIT")
-        } catch (err) {
-            await client.query("ROLLBACK")
-            throw err
-        } finally {
-            client.release()
-        }
+        await this.eventStore.append({
+            events: new CourseTitleWasChangedEvent({ courseId, newTitle }),
+            condition: appendCondition
+        })
+        await this.handlerCatchup.catchupHandlers(this.handlers)
     }
 
     async subscribeStudentToCourse(cmd: { courseId: string; studentId: string }) {
         const { courseId, studentId } = cmd
-        const client = await this.pool.connect()
-        await client.query("BEGIN transaction isolation level serializable")
-        try {
-            const eventStore = new PostgresEventStore(client)
 
-            const { state, appendCondition } = await buildDecisionModel(eventStore, {
-                courseExists: CourseExists(courseId),
-                courseCapacity: CourseCapacity(courseId),
-                studentAlreadySubscribed: StudentAlreadySubscribed({
-                    courseId: courseId,
-                    studentId: studentId
-                }),
-                studentSubscriptions: StudentSubscriptions(studentId)
-            })
+        const { state, appendCondition } = await buildDecisionModel(this.eventStore, {
+            courseExists: CourseExists(courseId),
+            courseCapacity: CourseCapacity(courseId),
+            studentAlreadySubscribed: StudentAlreadySubscribed({ courseId, studentId }),
+            studentSubscriptions: StudentSubscriptions(studentId)
+        })
 
-            if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
+        if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
+        if (state.courseCapacity.subscriberCount >= state.courseCapacity.capacity)
+            throw new Error(`Course ${courseId} is full.`)
+        if (state.studentAlreadySubscribed)
+            throw new Error(`Student ${studentId} already subscribed to course ${courseId}.`)
+        if (state.studentSubscriptions.subscriptionCount >= STUDENT_SUBSCRIPTION_LIMIT)
+            throw new Error(`Student ${studentId} is already subscribed to the maximum number of courses`)
 
-            if (state.courseCapacity.subscriberCount >= state.courseCapacity.capacity)
-                throw new Error(`Course ${courseId} is full.`)
-
-            if (state.studentAlreadySubscribed)
-                throw new Error(`Student ${studentId} already subscribed to course ${courseId}.`)
-
-            if (state.studentSubscriptions.subscriptionCount >= STUDENT_SUBSCRIPTION_LIMIT)
-                throw new Error(`Student ${studentId} is already subscribed to the maximum number of courses`)
-
-            await eventStore.append(new StudentWasSubscribedEvent({ courseId, studentId }), appendCondition)
-
-            const handlerCatchup = new HandlerCatchup(client, eventStore)
-            await handlerCatchup.catchupHandlers(setupHandlers(client))
-            await client.query("COMMIT")
-        } catch (err) {
-            await client.query("ROLLBACK")
-            throw err
-        } finally {
-            client.release()
-        }
+        await this.eventStore.append({
+            events: new StudentWasSubscribedEvent({ courseId, studentId }),
+            condition: appendCondition
+        })
+        await this.handlerCatchup.catchupHandlers(this.handlers)
     }
 
     async unsubscribeStudentFromCourse(cmd: { courseId: string; studentId: string }) {
         const { courseId, studentId } = cmd
-        const client = await this.pool.connect()
-        await client.query("BEGIN transaction isolation level serializable")
-        try {
-            const eventStore = new PostgresEventStore(client)
 
-            const { state, appendCondition } = await buildDecisionModel(eventStore, {
-                studentAlreadySubscribed: StudentAlreadySubscribed({
-                    courseId: courseId,
-                    studentId: studentId
-                }),
-                courseExists: CourseExists(courseId)
-            })
+        const { state, appendCondition } = await buildDecisionModel(this.eventStore, {
+            studentAlreadySubscribed: StudentAlreadySubscribed({ courseId, studentId }),
+            courseExists: CourseExists(courseId)
+        })
 
-            if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
-            if (!state.studentAlreadySubscribed)
-                throw new Error(`Student ${studentId} is not subscribed to course ${courseId}.`)
+        if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
+        if (!state.studentAlreadySubscribed)
+            throw new Error(`Student ${studentId} is not subscribed to course ${courseId}.`)
 
-            await eventStore.append(new StudentWasUnsubscribedEvent({ courseId, studentId }), appendCondition)
-
-            const handlerCatchup = new HandlerCatchup(client, eventStore)
-            await handlerCatchup.catchupHandlers(setupHandlers(client))
-            await client.query("COMMIT")
-        } catch (err) {
-            await client.query("ROLLBACK")
-            throw err
-        } finally {
-            client.release()
-        }
+        await this.eventStore.append({
+            events: new StudentWasUnsubscribedEvent({ courseId, studentId }),
+            condition: appendCondition
+        })
+        await this.handlerCatchup.catchupHandlers(this.handlers)
     }
 }

--- a/examples/course-manager-cli-with-readmodel/src/api/DecisionModels.ts
+++ b/examples/course-manager-cli-with-readmodel/src/api/DecisionModels.ts
@@ -64,6 +64,7 @@ export const StudentAlreadyRegistered = (studentId: string): EventHandlerWithSta
 })
 
 export const NextStudentNumber = (): EventHandlerWithState<StudentWasRegistered, number> => ({
+    tagFilter: Tags.fromObj({ studentNumberIndex: "global" }),
     init: 1,
     onlyLastEvent: true,
     when: {

--- a/examples/course-manager-cli-with-readmodel/src/api/Events.ts
+++ b/examples/course-manager-cli-with-readmodel/src/api/Events.ts
@@ -20,7 +20,9 @@ export class StudentWasRegistered implements DcbEvent {
     public metadata: unknown = {}
 
     constructor({ studentId, name, studentNumber }: { studentId: string; name: string; studentNumber: number }) {
-        this.tags = Tags.fromObj({ studentId })
+        // studentNumberIndex tag enables scoped locking for the NextStudentNumber decision model.
+        // Without it, the global student number query has no tag to lock on.
+        this.tags = Tags.fromObj({ studentId, studentNumberIndex: "global" })
         this.data = { studentId, name, studentNumber }
     }
 }

--- a/examples/course-manager-cli-with-readmodel/src/api/PostgresCourseSubscriptionsProjection.ts
+++ b/examples/course-manager-cli-with-readmodel/src/api/PostgresCourseSubscriptionsProjection.ts
@@ -7,11 +7,11 @@ import {
     StudentWasUnsubscribedEvent
 } from "./Events"
 import { PostgresCourseSubscriptionsRepository } from "../postgresCourseSubscriptionRepository/PostgresCourseSubscriptionRespository"
-import { Pool, PoolClient } from "pg"
+import { Pool } from "pg"
 import { EventHandler } from "@dcb-es/event-store"
 
 export const PostgresCourseSubscriptionsProjection = (
-    client: PoolClient | Pool
+    pool: Pool
 ): EventHandler<
     | CourseWasRegisteredEvent
     | CourseCapacityWasChangedEvent
@@ -22,19 +22,19 @@ export const PostgresCourseSubscriptionsProjection = (
 > => ({
     when: {
         courseWasRegistered: async ({ event: { data } }) => {
-            const repository = PostgresCourseSubscriptionsRepository(client)
+            const repository = PostgresCourseSubscriptionsRepository(pool)
             await repository.registerCourse({ courseId: data.courseId, title: data.title, capacity: data.capacity })
         },
         courseTitleWasChanged: async ({ event: { data } }) => {
-            const repository = PostgresCourseSubscriptionsRepository(client)
+            const repository = PostgresCourseSubscriptionsRepository(pool)
             await repository.updateCourseTitle({ courseId: data.courseId, newTitle: data.newTitle })
         },
         courseCapacityWasChanged: async ({ event: { data } }) => {
-            const repository = PostgresCourseSubscriptionsRepository(client)
+            const repository = PostgresCourseSubscriptionsRepository(pool)
             await repository.updateCourseCapacity({ courseId: data.courseId, newCapacity: data.newCapacity })
         },
         studentWasRegistered: async ({ event: { data } }) => {
-            const repository = PostgresCourseSubscriptionsRepository(client)
+            const repository = PostgresCourseSubscriptionsRepository(pool)
             await repository.registerStudent({
                 studentId: data.studentId,
                 name: data.name,
@@ -42,11 +42,11 @@ export const PostgresCourseSubscriptionsProjection = (
             })
         },
         studentWasSubscribed: async ({ event: { data } }) => {
-            const repository = PostgresCourseSubscriptionsRepository(client)
+            const repository = PostgresCourseSubscriptionsRepository(pool)
             await repository.subscribeStudentToCourse({ studentId: data.studentId, courseId: data.courseId })
         },
         studentWasUnsubscribed: async ({ event: { data } }) => {
-            const repository = PostgresCourseSubscriptionsRepository(client)
+            const repository = PostgresCourseSubscriptionsRepository(pool)
             await repository.unsubscribeStudentFromCourse({ studentId: data.studentId, courseId: data.courseId })
         }
     }

--- a/examples/course-manager-cli/index.ts
+++ b/examples/course-manager-cli/index.ts
@@ -13,7 +13,7 @@ import { PostgresEventStore } from "@dcb-es/event-store-postgres"
     }
 
     const pool = new Pool(postgresConfig)
-    const eventStore = new PostgresEventStore(pool)
+    const eventStore = new PostgresEventStore({ pool })
     await eventStore.ensureInstalled()
 
     const api = new Api(eventStore)

--- a/examples/course-manager-cli/src/api/Api.tests.ts
+++ b/examples/course-manager-cli/src/api/Api.tests.ts
@@ -1,4 +1,4 @@
-import { Pool, PoolClient } from "pg"
+import { Pool } from "pg"
 import { Api } from "./Api"
 import { getTestPgDatabasePool } from "@test/testPgDbPool"
 import { PostgresEventStore } from "@dcb-es/event-store-postgres"
@@ -12,25 +12,16 @@ const COURSE_1 = {
 describe("EventSourcedApi", () => {
     let pool: Pool
     let api: Api
-    let client: PoolClient
 
     beforeAll(async () => {
         pool = await getTestPgDatabasePool()
-        const eventStore = new PostgresEventStore(pool)
+        const eventStore = new PostgresEventStore({ pool })
         await eventStore.ensureInstalled()
-    })
-
-    beforeEach(async () => {
-        client = await pool.connect()
-        await client.query("BEGIN transaction isolation level serializable")
-        const eventStore = new PostgresEventStore(client)
         api = new Api(eventStore)
     })
 
     afterEach(async () => {
-        client.query("ROLLBACK;")
-        client.release()
-        await client.query("DELETE FROM events")
+        await pool.query("DELETE FROM events")
     })
 
     afterAll(async () => {

--- a/examples/course-manager-cli/src/api/Api.ts
+++ b/examples/course-manager-cli/src/api/Api.ts
@@ -31,10 +31,10 @@ export class Api {
 
         if (state.courseExists) throw new Error(`Course with id ${cmd.id} already exists`)
 
-        await this.eventStore.append(
-            new CourseWasRegisteredEvent({ courseId: cmd.id, title: cmd.title, capacity: cmd.capacity }),
-            appendCondition
-        )
+        await this.eventStore.append({
+            events: new CourseWasRegisteredEvent({ courseId: cmd.id, title: cmd.title, capacity: cmd.capacity }),
+            condition: appendCondition
+        })
     }
 
     async registerStudent(cmd: { id: string; name: string }) {
@@ -46,10 +46,10 @@ export class Api {
 
         if (state.studentAlreadyRegistered) throw new Error(`Student with id ${id} already registered.`)
 
-        await this.eventStore.append(
-            new StudentWasRegistered({ studentId: id, name, studentNumber: state.nextStudentNumber }),
-            appendCondition
-        )
+        await this.eventStore.append({
+            events: new StudentWasRegistered({ studentId: id, name, studentNumber: state.nextStudentNumber }),
+            condition: appendCondition
+        })
     }
 
     async updateCourseCapacity(cmd: { courseId: string; newCapacity: number }) {
@@ -64,7 +64,10 @@ export class Api {
         if (state.CourseCapacity.capacity === newCapacity)
             throw new Error("New capacity is the same as the current capacity.")
 
-        await this.eventStore.append(new CourseCapacityWasChangedEvent({ courseId, newCapacity }), appendCondition)
+        await this.eventStore.append({
+            events: new CourseCapacityWasChangedEvent({ courseId, newCapacity }),
+            condition: appendCondition
+        })
     }
 
     async updateCourseTitle(cmd: { courseId: string; newTitle: string }) {
@@ -78,7 +81,10 @@ export class Api {
         if (!state.courseExists) throw new Error(`Course ${courseId} doesn't exist.`)
         if (state.courseTitle === newTitle) throw new Error("New title is the same as the current title.")
 
-        await this.eventStore.append(new CourseTitleWasChangedEvent({ courseId, newTitle }), appendCondition)
+        await this.eventStore.append({
+            events: new CourseTitleWasChangedEvent({ courseId, newTitle }),
+            condition: appendCondition
+        })
     }
 
     async subscribeStudentToCourse(cmd: { courseId: string; studentId: string }) {
@@ -105,7 +111,10 @@ export class Api {
         if (state.studentSubscriptions.subscriptionCount >= STUDENT_SUBSCRIPTION_LIMIT)
             throw new Error(`Student ${studentId} is already subscribed to the maximum number of courses`)
 
-        await this.eventStore.append(new StudentWasSubscribedEvent({ courseId, studentId }), appendCondition)
+        await this.eventStore.append({
+            events: new StudentWasSubscribedEvent({ courseId, studentId }),
+            condition: appendCondition
+        })
     }
 
     async unsubscribeStudentFromCourse(cmd: { courseId: string; studentId: string }) {
@@ -123,6 +132,9 @@ export class Api {
         if (!state.studentAlreadySubscribed)
             throw new Error(`Student ${studentId} is not subscribed to course ${courseId}.`)
 
-        await this.eventStore.append(new StudentWasUnsubscribedEvent({ courseId, studentId }), appendCondition)
+        await this.eventStore.append({
+            events: new StudentWasUnsubscribedEvent({ courseId, studentId }),
+            condition: appendCondition
+        })
     }
 }

--- a/examples/course-manager-cli/src/api/DecisionModels.ts
+++ b/examples/course-manager-cli/src/api/DecisionModels.ts
@@ -64,6 +64,7 @@ export const StudentAlreadyRegistered = (studentId: string): EventHandlerWithSta
 })
 
 export const NextStudentNumber = (): EventHandlerWithState<StudentWasRegistered, number> => ({
+    tagFilter: Tags.fromObj({ studentNumberIndex: "global" }),
     init: 1,
     onlyLastEvent: true,
     when: {

--- a/examples/course-manager-cli/src/api/Events.ts
+++ b/examples/course-manager-cli/src/api/Events.ts
@@ -20,7 +20,9 @@ export class StudentWasRegistered implements DcbEvent {
     public metadata: unknown = {}
 
     constructor({ studentId, name, studentNumber }: { studentId: string; name: string; studentNumber: number }) {
-        this.tags = Tags.fromObj({ studentId })
+        // studentNumberIndex tag enables scoped locking for the NextStudentNumber decision model.
+        // Without it, the global student number query has no tag to lock on.
+        this.tags = Tags.fromObj({ studentId, studentNumberIndex: "global" })
         this.data = { studentId, name, studentNumber }
     }
 }

--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.ts
@@ -9,7 +9,8 @@ import {
     SequencePosition,
     ReadOptions,
     Query,
-    ensureIsArray
+    ensureIsArray,
+    validateAppendCondition
 } from "@dcb-es/event-store"
 import { dbEventConverter } from "./utils"
 import { readSqlWithCursor } from "./readSql"
@@ -78,6 +79,9 @@ export class PostgresEventStore implements EventStore {
 
     async append(command: AppendCommand | AppendCommand[]): Promise<SequencePosition> {
         const commands = ensureIsArray(command)
+        for (const cmd of commands) {
+            if (cmd.condition) validateAppendCondition(cmd.condition)
+        }
 
         if (commands.length === 1) {
             const evts = ensureIsArray(commands[0].events)

--- a/packages/event-store-postgres/src/eventStore/advisoryLocks.tests.ts
+++ b/packages/event-store-postgres/src/eventStore/advisoryLocks.tests.ts
@@ -53,32 +53,8 @@ describe("computeLockKeys", () => {
         expect(shared.length).toBeGreaterThan(0)
     })
 
-    it("rejects Query.all() conditions", () => {
-        const event = { type: "Foo", tags: Tags.fromObj({ x: "1" }), data: {}, metadata: {} }
-        const cond = { failIfEventsMatch: Query.all(), after: SequencePosition.initial() }
-
-        expect(() => computeLockKeys([event], cond)).toThrow("Query.all() is not supported")
-    })
-
-    it("rejects condition items missing types", () => {
-        const event = { type: "Foo", tags: Tags.fromObj({ x: "1" }), data: {}, metadata: {} }
-        const cond = {
-            failIfEventsMatch: Query.fromItems([{ tags: Tags.fromObj({ x: "1" }) }]),
-            after: SequencePosition.initial()
-        }
-
-        expect(() => computeLockKeys([event], cond)).toThrow("at least one type and one tag")
-    })
-
-    it("rejects condition items missing tags", () => {
-        const event = { type: "Foo", tags: Tags.fromObj({ x: "1" }), data: {}, metadata: {} }
-        const cond = {
-            failIfEventsMatch: Query.fromItems([{ types: ["Foo"] }]),
-            after: SequencePosition.initial()
-        }
-
-        expect(() => computeLockKeys([event], cond)).toThrow("at least one type and one tag")
-    })
+    // Validation of types+tags is now enforced globally by validateAppendCondition
+    // at the store level. computeLockKeys trusts its precondition.
 
     it("returns unique bigint keys (no bucketing)", () => {
         const events = Array.from({ length: 100 }, (_, i) => ({

--- a/packages/event-store-postgres/src/eventStore/advisoryLocks.ts
+++ b/packages/event-store-postgres/src/eventStore/advisoryLocks.ts
@@ -12,23 +12,16 @@ import { DcbEvent, AppendCondition } from "@dcb-es/event-store"
  *
  * Keys are NOT sorted client-side — Postgres ORDER BY in the acquisition
  * query handles deadlock prevention.
+ *
+ * Precondition: condition items must have types + tags (enforced by validateAppendCondition).
  */
 export function computeLockKeys(events: DcbEvent[], condition?: AppendCondition): bigint[] {
     const keys = new Set<bigint>()
 
-    if (condition) {
-        const query = condition.failIfEventsMatch
-        if (query.isAll) {
-            throw new Error("This event store requires scoped conditions. Query.all() is not supported.")
-        }
-        for (const item of query.items) {
-            if (!item.types?.length || !item.tags || item.tags.values.length === 0) {
-                throw new Error(
-                    "This event store requires every condition query item to specify at least one type and one tag."
-                )
-            }
-            for (const type of item.types) {
-                for (const tag of item.tags.values) {
+    if (condition && !condition.failIfEventsMatch.isAll) {
+        for (const item of condition.failIfEventsMatch.items) {
+            for (const type of item.types ?? []) {
+                for (const tag of item.tags?.values ?? []) {
                     keys.add(fnv1a32(`${type}|${tag}`))
                 }
             }

--- a/packages/event-store/index.ts
+++ b/packages/event-store/index.ts
@@ -4,7 +4,8 @@ export {
     SequencedEvent,
     AppendCondition,
     AppendCommand,
-    ReadOptions
+    ReadOptions,
+    validateAppendCondition
 } from "./src/eventStore/EventStore"
 export { AppendConditionError } from "./src/eventStore/AppendConditionError"
 

--- a/packages/event-store/src/eventStore/AppendConditionError.tests.ts
+++ b/packages/event-store/src/eventStore/AppendConditionError.tests.ts
@@ -6,7 +6,7 @@ import { Tags } from "./Tags"
 
 describe("AppendConditionError", () => {
     const createAppendCondition = (ceiling: string = "1"): AppendCondition => ({
-        failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+        failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.fromObj({ id: "test" }) }]),
         after: SequencePosition.fromString(ceiling)
     })
 

--- a/packages/event-store/src/eventStore/EventStore.ts
+++ b/packages/event-store/src/eventStore/EventStore.ts
@@ -16,9 +16,25 @@ export interface SequencedEvent<T extends DcbEvent = DcbEvent> {
     position: SequencePosition
 }
 
+/**
+ * Every query item in failIfEventsMatch must specify at least one type AND one tag.
+ * This enables scoped locking — without it, the store cannot determine which
+ * concurrent transactions conflict.
+ */
 export type AppendCondition = {
     failIfEventsMatch: Query
     after?: SequencePosition
+}
+
+export function validateAppendCondition(condition: AppendCondition): void {
+    if (condition.failIfEventsMatch.isAll) {
+        throw new Error("AppendCondition requires scoped conditions. Query.all() is not supported.")
+    }
+    for (const item of condition.failIfEventsMatch.items) {
+        if (!item.types?.length || !item.tags || item.tags.values.length === 0) {
+            throw new Error("AppendCondition requires every query item to specify at least one type and one tag.")
+        }
+    }
 }
 
 export interface ReadOptions {

--- a/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.append.tests.ts
+++ b/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.append.tests.ts
@@ -12,7 +12,7 @@ class EventType1 implements DcbEvent {
     metadata: Record<string, never> = {}
 
     constructor(tagValue?: string) {
-        this.tags = tagValue ? Tags.fromObj({ testTagKey: tagValue }) : Tags.from([])
+        this.tags = Tags.fromObj({ testTagKey: tagValue ?? "default" })
         this.data = {}
     }
 }
@@ -42,7 +42,9 @@ describe("memoryEventStore.append", () => {
         })
         describe("when append condition with types filter and after provided", () => {
             const condition: AppendCondition = {
-                failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+                failIfEventsMatch: Query.fromItems([
+                    { types: ["testEvent1"], tags: Tags.fromObj({ testTagKey: "default" }) }
+                ]),
                 after: SequencePosition.fromString("1")
             }
             test("should successfully append an event without throwing under specified conditions", async () => {
@@ -84,7 +86,9 @@ describe("memoryEventStore.append", () => {
 
         describe("when append condition with types filter and after provided", () => {
             const condition: AppendCondition = {
-                failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }]),
+                failIfEventsMatch: Query.fromItems([
+                    { types: ["testEvent1"], tags: Tags.fromObj({ testTagKey: "default" }) }
+                ]),
                 after: SequencePosition.initial()
             }
             test("should throw an error if appended event exceeds the maximum allowed sequence number", async () => {
@@ -166,7 +170,9 @@ describe("memoryEventStore.append", () => {
         describe("when append condition with after omitted (undefined)", () => {
             test("should throw when matching events exist and after is undefined", async () => {
                 const condition: AppendCondition = {
-                    failIfEventsMatch: Query.fromItems([{ types: ["testEvent1"], tags: Tags.createEmpty() }])
+                    failIfEventsMatch: Query.fromItems([
+                        { types: ["testEvent1"], tags: Tags.fromObj({ testTagKey: "default" }) }
+                    ])
                 }
                 await expect(eventStore.append({ events: new EventType1(), condition })).rejects.toThrow(
                     AppendConditionError
@@ -175,7 +181,9 @@ describe("memoryEventStore.append", () => {
 
             test("should succeed when no matching events exist and after is undefined", async () => {
                 const condition: AppendCondition = {
-                    failIfEventsMatch: Query.fromItems([{ types: ["nonExistentEvent"], tags: Tags.createEmpty() }])
+                    failIfEventsMatch: Query.fromItems([
+                        { types: ["nonExistentEvent"], tags: Tags.fromObj({ testTagKey: "default" }) }
+                    ])
                 }
                 await expect(eventStore.append({ events: new EventType1(), condition })).resolves.not.toThrow()
             })
@@ -185,8 +193,8 @@ describe("memoryEventStore.append", () => {
             test("should throw when any query item matches", async () => {
                 const condition: AppendCondition = {
                     failIfEventsMatch: Query.fromItems([
-                        { types: ["nonExistentEvent"], tags: Tags.createEmpty() },
-                        { types: ["testEvent1"], tags: Tags.createEmpty() }
+                        { types: ["nonExistentEvent"], tags: Tags.fromObj({ testTagKey: "default" }) },
+                        { types: ["testEvent1"], tags: Tags.fromObj({ testTagKey: "default" }) }
                     ]),
                     after: SequencePosition.initial()
                 }
@@ -198,8 +206,8 @@ describe("memoryEventStore.append", () => {
             test("should succeed when no query items match", async () => {
                 const condition: AppendCondition = {
                     failIfEventsMatch: Query.fromItems([
-                        { types: ["nonExistentEvent1"], tags: Tags.createEmpty() },
-                        { types: ["nonExistentEvent2"], tags: Tags.createEmpty() }
+                        { types: ["nonExistentEvent1"], tags: Tags.fromObj({ testTagKey: "default" }) },
+                        { types: ["nonExistentEvent2"], tags: Tags.fromObj({ testTagKey: "default" }) }
                     ]),
                     after: SequencePosition.initial()
                 }

--- a/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.ts
+++ b/packages/event-store/src/eventStore/memoryEventStore/MemoryEventStore.ts
@@ -1,4 +1,4 @@
-import { SequencedEvent, EventStore, AppendCommand, ReadOptions } from "../EventStore"
+import { SequencedEvent, EventStore, AppendCommand, ReadOptions, validateAppendCondition } from "../EventStore"
 import { AppendConditionError } from "../AppendConditionError"
 import { SequencePosition } from "../SequencePosition"
 import { Timestamp } from "../Timestamp"
@@ -78,6 +78,7 @@ export class MemoryEventStore implements EventStore {
             const evts = ensureIsArray(cmd.events)
 
             if (cmd.condition) {
+                validateAppendCondition(cmd.condition)
                 const { failIfEventsMatch, after } = cmd.condition
                 const matchingEvents = getMatchingEvents(failIfEventsMatch, after, snapshot)
                 if (matchingEvents.length > 0) {


### PR DESCRIPTION
## Summary

Updates both example apps for the new API and enforces types+tags on all append conditions globally.

### Examples
- `new PostgresEventStore(pool)` → `new PostgresEventStore({ pool })`
- `append(event, condition)` → `append({ events, condition })`
- **Removed all `BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE` / `COMMIT` / `ROLLBACK`** — store manages its own transactions
- **Readmodel example**: store and catchup now run as separate isolated transactions (was incorrectly sharing one transaction)
- `Api` constructor takes `pool + eventStore + handlerCatchup` (created once at startup, not per-request)

### Core: `validateAppendCondition`
Every condition query item must specify at least one type AND one tag. Enforced in both `MemoryEventStore` and `PostgresEventStore`. This is what enables scoped locking — without tags, the lock system can't determine conflict scope.

Duplicate validation removed from `advisoryLocks.ts` (now a precondition enforced at store level).

### Domain: `studentNumberIndex` tag
`StudentWasRegistered` events now carry `studentNumberIndex=global` tag. This gives the `NextStudentNumber` decision model a tag to lock on — without it, the global student number query had no scope for the advisory lock system.

## Test plan
- [x] 298 tests passing across entire monorepo (134 core + 147 postgres + 2 example1 + 15 example2)
- [x] Lint clean
- [x] Build clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)