### PR TITLE
feat: runHandler — subscribe-based handler runner with atomic bookmarks

### DIFF
--- a/packages/event-store-postgres/index.ts
+++ b/packages/event-store-postgres/index.ts
@@ -3,3 +3,5 @@ export type { PostgresEventStoreOptions } from "./src/eventStore/PostgresEventSt
 export type { LockStrategy } from "./src/eventStore/lockStrategy"
 export { advisoryLocks, rowLocks } from "./src/eventStore/lockStrategy"
 export { HandlerCatchup } from "./src/eventHandling/HandlerCatchup"
+export { runHandler } from "./src/eventHandling/runHandler"
+export type { HandlerRunnerOptions, RunningHandler } from "./src/eventHandling/runHandler"

--- a/packages/event-store-postgres/src/eventHandling/HandlerCatchup.ts
+++ b/packages/event-store-postgres/src/eventHandling/HandlerCatchup.ts
@@ -4,6 +4,10 @@ import { ensureHandlersInstalled, registerHandlers } from "./ensureHandlersInsta
 
 export type HandlerCheckPoints = Record<string, SequencePosition>
 
+/**
+ * @deprecated Use `runHandler()` instead — subscribe-based, atomic bookmark+projection,
+ * with NOTIFY on bookmark advance for `waitUntilProcessed()` support.
+ */
 export class HandlerCatchup {
     private tableName: string
 

--- a/packages/event-store-postgres/src/eventHandling/runHandler.tests.ts
+++ b/packages/event-store-postgres/src/eventHandling/runHandler.tests.ts
@@ -1,0 +1,262 @@
+import { Pool } from "pg"
+import { DcbEvent, Tags } from "@dcb-es/event-store"
+import { PostgresEventStore } from "../eventStore/PostgresEventStore"
+import { runHandler } from "./runHandler"
+import { ensureHandlersInstalled } from "./ensureHandlersInstalled"
+import { getTestPgDatabasePool } from "@test/testPgDbPool"
+
+const event = (type: string, tags: Tags = Tags.fromObj({ e: "1" }), data: unknown = {}): DcbEvent => ({
+    type,
+    tags,
+    data,
+    metadata: {}
+})
+
+describe("runHandler", () => {
+    let pool: Pool
+    let store: PostgresEventStore
+    const HANDLER_NAME = "TestProjection"
+
+    beforeAll(async () => {
+        pool = await getTestPgDatabasePool({ max: 20 })
+        store = new PostgresEventStore({ pool })
+        await store.ensureInstalled()
+        await ensureHandlersInstalled(pool, [HANDLER_NAME], "_handler_bookmarks")
+    })
+
+    afterEach(async () => {
+        await pool.query("TRUNCATE table events")
+        await pool.query("ALTER SEQUENCE events_sequence_position_seq RESTART WITH 1")
+        await pool.query("UPDATE _handler_bookmarks SET last_sequence_position = 0")
+    })
+
+    afterAll(async () => {
+        if (pool) await pool.end()
+    })
+
+    test("processes historical events and advances bookmark", async () => {
+        await store.append({ events: event("A") })
+        await store.append({ events: event("B") })
+
+        const processed: string[] = []
+        const controller = new AbortController()
+
+        const { promise } = runHandler({
+            pool,
+            eventStore: store,
+            handlerName: HANDLER_NAME,
+            handlerFactory: () => ({
+                when: {
+                    A: async ({ event: { type } }) => {
+                        processed.push(type)
+                    },
+                    B: async ({ event: { type } }) => {
+                        processed.push(type)
+                        controller.abort()
+                    }
+                }
+            }),
+            signal: controller.signal
+        })
+
+        await promise
+        expect(processed).toEqual(["A", "B"])
+
+        const bookmark = await pool.query(
+            "SELECT last_sequence_position FROM _handler_bookmarks WHERE handler_id = $1",
+            [HANDLER_NAME]
+        )
+        expect(Number(bookmark.rows[0].last_sequence_position)).toBe(2)
+    })
+
+    test("processes live events as they arrive", async () => {
+        const processed: string[] = []
+        const controller = new AbortController()
+
+        const { promise } = runHandler({
+            pool,
+            eventStore: store,
+            handlerName: HANDLER_NAME,
+            handlerFactory: () => ({
+                when: {
+                    Live: async ({ event: { type } }) => {
+                        processed.push(type)
+                        if (processed.length >= 2) controller.abort()
+                    }
+                }
+            }),
+            signal: controller.signal
+        })
+
+        await store.append({ events: event("Live") })
+        await store.append({ events: event("Live") })
+
+        await promise
+        expect(processed).toEqual(["Live", "Live"])
+    })
+
+    test("bookmark + projection update are atomic", async () => {
+        let callCount = 0
+        const controller = new AbortController()
+
+        const { promise } = runHandler({
+            pool,
+            eventStore: store,
+            handlerName: HANDLER_NAME,
+            handlerFactory: client => ({
+                when: {
+                    Counter: async () => {
+                        callCount++
+                        await client.query("CREATE TABLE IF NOT EXISTS _test_counter (n INT)")
+                        await client.query("INSERT INTO _test_counter VALUES ($1)", [callCount])
+                        controller.abort()
+                    }
+                }
+            }),
+            signal: controller.signal
+        })
+
+        await store.append({ events: event("Counter") })
+        await promise
+
+        const counter = await pool.query("SELECT COUNT(*) as n FROM _test_counter")
+        expect(Number(counter.rows[0].n)).toBe(1)
+
+        const bookmark = await pool.query(
+            "SELECT last_sequence_position FROM _handler_bookmarks WHERE handler_id = $1",
+            [HANDLER_NAME]
+        )
+        expect(Number(bookmark.rows[0].last_sequence_position)).toBe(1)
+
+        await pool.query("DROP TABLE IF EXISTS _test_counter")
+    })
+
+    test("fires NOTIFY on bookmark advance", async () => {
+        const controller = new AbortController()
+        const notifications: string[] = []
+
+        const listener = await pool.connect()
+        await listener.query("LISTEN _handler_bookmarks")
+        listener.on("notification", msg => {
+            if (msg.payload) notifications.push(msg.payload)
+        })
+
+        const { promise } = runHandler({
+            pool,
+            eventStore: store,
+            handlerName: HANDLER_NAME,
+            handlerFactory: () => ({
+                when: {
+                    Notify: async () => {
+                        controller.abort()
+                    }
+                }
+            }),
+            signal: controller.signal
+        })
+
+        await store.append({ events: event("Notify") })
+        await promise
+
+        // Give notification time to arrive
+        await new Promise(r => setTimeout(r, 50))
+
+        await listener.query("UNLISTEN _handler_bookmarks")
+        listener.release()
+
+        expect(notifications.length).toBe(1)
+        expect(notifications[0]).toBe(`${HANDLER_NAME}:1`)
+    })
+
+    test("handler restart resumes from bookmark (no reprocessing of committed events)", async () => {
+        await store.append({ events: event("First") })
+
+        // First run: process one event then abort
+        const controller1 = new AbortController()
+
+        const { promise: p1 } = runHandler({
+            pool,
+            eventStore: store,
+            handlerName: HANDLER_NAME,
+            handlerFactory: () => ({
+                when: {
+                    First: async () => {
+                        controller1.abort()
+                    }
+                }
+            }),
+            signal: controller1.signal
+        })
+        await p1
+
+        // Bookmark should be at 1
+        const bm1 = await pool.query("SELECT last_sequence_position FROM _handler_bookmarks WHERE handler_id = $1", [
+            HANDLER_NAME
+        ])
+        expect(Number(bm1.rows[0].last_sequence_position)).toBe(1)
+
+        // Append another event
+        await store.append({ events: event("Second") })
+
+        // Second run: should resume from bookmark (position 1), only see "Second"
+        const controller2 = new AbortController()
+        const run2Processed: string[] = []
+
+        const { promise: p2 } = runHandler({
+            pool,
+            eventStore: store,
+            handlerName: HANDLER_NAME,
+            handlerFactory: () => ({
+                when: {
+                    First: async () => {
+                        run2Processed.push("First")
+                    },
+                    Second: async () => {
+                        run2Processed.push("Second")
+                        controller2.abort()
+                    }
+                }
+            }),
+            signal: controller2.signal
+        })
+        await p2
+        expect(run2Processed).toEqual(["Second"])
+    })
+
+    test("handler error propagates via promise rejection", async () => {
+        await store.append({ events: event("Boom") })
+
+        const { promise } = runHandler({
+            pool,
+            eventStore: store,
+            handlerName: HANDLER_NAME,
+            handlerFactory: () => ({
+                when: {
+                    Boom: async () => {
+                        throw new Error("handler exploded")
+                    }
+                }
+            })
+        })
+
+        await expect(promise).rejects.toThrow("handler exploded")
+
+        // Bookmark should NOT have advanced (transaction rolled back)
+        const bookmark = await pool.query(
+            "SELECT last_sequence_position FROM _handler_bookmarks WHERE handler_id = $1",
+            [HANDLER_NAME]
+        )
+        expect(Number(bookmark.rows[0].last_sequence_position)).toBe(0)
+    })
+
+    test("rejects handler names containing colon", () => {
+        expect(() =>
+            runHandler({
+                pool,
+                eventStore: store,
+                handlerName: "bad:name",
+                handlerFactory: () => ({ when: {} })
+            })
+        ).toThrow('must not contain ":"')
+    })
+})

--- a/packages/event-store-postgres/src/eventHandling/runHandler.ts
+++ b/packages/event-store-postgres/src/eventHandling/runHandler.ts
@@ -46,8 +46,14 @@ export function runHandler(options: HandlerRunnerOptions): RunningHandler {
 
         let position = SequencePosition.fromString(String(row.last_sequence_position))
 
-        // Build query from handler's event types (create a temporary handler to inspect keys)
-        const sampleHandler = handlerFactory(null as unknown as PoolClient)
+        // Inspect handler keys to build the subscribe query.
+        // Unlike append conditions, subscribe queries don't require types+tags — Query.all() is valid.
+        let sampleHandler
+        try {
+            sampleHandler = handlerFactory(null as unknown as PoolClient)
+        } catch {
+            throw new Error(`handlerFactory for "${handlerName}" must not access the client during construction.`)
+        }
         const types = Object.keys(sampleHandler.when) as string[]
         const query =
             types.length > 0 && sampleHandler.tagFilter
@@ -55,6 +61,7 @@ export function runHandler(options: HandlerRunnerOptions): RunningHandler {
                 : Query.all()
 
         for await (const event of eventStore.subscribe(query, { after: position, signal })) {
+            if (signal?.aborted) break
             const client = await pool.connect()
             try {
                 await client.query("BEGIN")

--- a/packages/event-store-postgres/src/eventHandling/runHandler.ts
+++ b/packages/event-store-postgres/src/eventHandling/runHandler.ts
@@ -1,0 +1,88 @@
+import { Pool, PoolClient } from "pg"
+import { EventHandler, EventStore, Query, SequencePosition, Tags } from "@dcb-es/event-store"
+
+export interface HandlerRunnerOptions {
+    pool: Pool
+    eventStore: EventStore
+    handlerName: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handlerFactory: (client: PoolClient) => EventHandler<any, any>
+    bookmarkTableName?: string
+    signal?: AbortSignal
+}
+
+export interface RunningHandler {
+    promise: Promise<void>
+}
+
+/**
+ * Start a subscribe-based handler that processes events and atomically
+ * updates a bookmark + fires NOTIFY on bookmark advance.
+ *
+ * Each event is processed in its own transaction: the handlerFactory
+ * receives the transaction client so projection writes are atomic with
+ * the bookmark update. If the transaction fails, neither advances.
+ *
+ * The returned promise resolves when the signal is aborted (after
+ * finishing the current event) or rejects on unrecoverable error.
+ * Callers decide retry policy.
+ */
+export function runHandler(options: HandlerRunnerOptions): RunningHandler {
+    const { pool, eventStore, handlerName, handlerFactory, signal } = options
+    const tableName = options.bookmarkTableName ?? "_handler_bookmarks"
+
+    if (handlerName.includes(":")) {
+        throw new Error(`Handler name "${handlerName}" must not contain ":" (used as notification delimiter)`)
+    }
+
+    const promise = (async () => {
+        const bookmarkResult = await pool.query(
+            `SELECT last_sequence_position FROM ${tableName} WHERE handler_id = $1`,
+            [handlerName]
+        )
+        const row = bookmarkResult.rows[0]
+        if (!row)
+            throw new Error(`Handler "${handlerName}" not found in ${tableName}. Call ensureHandlersInstalled first.`)
+
+        let position = SequencePosition.fromString(String(row.last_sequence_position))
+
+        // Build query from handler's event types (create a temporary handler to inspect keys)
+        const sampleHandler = handlerFactory(null as unknown as PoolClient)
+        const types = Object.keys(sampleHandler.when) as string[]
+        const query =
+            types.length > 0 && sampleHandler.tagFilter
+                ? Query.fromItems([{ types, tags: sampleHandler.tagFilter as Tags }])
+                : Query.all()
+
+        for await (const event of eventStore.subscribe(query, { after: position, signal })) {
+            const client = await pool.connect()
+            try {
+                await client.query("BEGIN")
+
+                const handler = handlerFactory(client)
+                if (handler.when[event.event.type]) {
+                    await handler.when[event.event.type](event)
+                }
+
+                await client.query(`UPDATE ${tableName} SET last_sequence_position = $1 WHERE handler_id = $2`, [
+                    event.position.toString(),
+                    handlerName
+                ])
+                await client.query("SELECT pg_notify($1, $2)", [
+                    tableName,
+                    `${handlerName}:${event.position.toString()}`
+                ])
+
+                await client.query("COMMIT")
+                position = event.position
+            } catch (err) {
+                await client.query("ROLLBACK").catch(() => {})
+                throw err
+            } finally {
+                client.release()
+            }
+        }
+    })()
+
+    return { promise }
+}


### PR DESCRIPTION
## Summary

Subscribe-based handler runner that replaces `HandlerCatchup`. Each event is processed in its own transaction with atomic bookmark + read model update + NOTIFY on bookmark advance.

### API
```typescript
const { promise } = runHandler({
    pool,
    eventStore,
    handlerName: "MeterListProjection",
    handlerFactory: (client) => PostgresCourseSubscriptionsProjection(client),
    signal: controller.signal
})
```

`handlerFactory` receives the transaction `PoolClient` — projection writes are atomic with the bookmark update. If the transaction fails, neither advances.

### Key properties
- **Atomic**: bookmark + projection in one transaction, NOTIFY after COMMIT
- **Resumable**: reads initial bookmark from DB, subscribe starts from there
- **Graceful shutdown**: AbortSignal finishes current event before stopping
- **Error propagation**: promise rejects on handler error, bookmark not advanced

### HandlerCatchup
Marked `@deprecated` with migration guide pointing to `runHandler`.

## Test plan
- [x] 174 postgres tests (7 new: historical, live, atomic, NOTIFY, restart, error, name validation)
- [x] Build clean, lint clean

Part of #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)