### PR TITLE
chore: bump to v7.0.0-alpha.1 and align package metadata

### DIFF
--- a/examples/course-manager-cli-with-readmodel/package.json
+++ b/examples/course-manager-cli-with-readmodel/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dcb-es/examples-course-manager-cli-with-readmodel",
     "author": "Paul Grimshaw",
-    "license": "MIT",
+    "license": "BSD-3-Clause",
     "version": "2.2.1",
     "private": true,
     "scripts": {
@@ -15,8 +15,8 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@dcb-es/event-store": "^5.1.3",
-        "@dcb-es/event-store-postgres": "^6.2.1",
+        "@dcb-es/event-store": "^7.0.0-alpha.1",
+        "@dcb-es/event-store-postgres": "^7.0.0-alpha.1",
         "inquirer": "^8.0.0",
         "interactive-cli": "^1.1.6"
     },

--- a/examples/course-manager-cli/package.json
+++ b/examples/course-manager-cli/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dcb-es/examples-course-manager-cli",
     "author": "Paul Grimshaw",
-    "license": "MIT",
+    "license": "BSD-3-Clause",
     "version": "2.2.1",
     "private": true,
     "scripts": {
@@ -15,8 +15,8 @@
         "prepare": "yarn build"
     },
     "dependencies": {
-        "@dcb-es/event-store": "^5.1.3",
-        "@dcb-es/event-store-postgres": "^6.2.1",
+        "@dcb-es/event-store": "^7.0.0-alpha.1",
+        "@dcb-es/event-store-postgres": "^7.0.0-alpha.1",
         "inquirer": "^8.0.0",
         "interactive-cli": "^1.1.6"
     },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/sennentech/dcb-event-store.git"
+        "url": "git+https://github.com/kraken-tech/dcb-event-store.git"
     },
-    "license": "MIT",
+    "license": "BSD-3-Clause",
     "dependencies": {
         "source-map-support": "^0.5.21"
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "watch": "npx lerna run watch",
         "lint": "npx lerna run lint",
         "lint-fix": "npx lerna run lint-fix",
-        "publish-all": "npm run build && npx lerna publish from-package --dist-tag alpha"
+        "clean": "npx lerna exec -- rm -rf dist",
+        "publish-all": "npm run clean && npm run build && npx lerna publish from-package --dist-tag alpha"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "watch": "npx lerna run watch",
         "lint": "npx lerna run lint",
         "lint-fix": "npx lerna run lint-fix",
-        "publish-all": "npx lerna publish"
+        "publish-all": "npm run build && npx lerna publish from-package --dist-tag alpha"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lint": "npx lerna run lint",
         "lint-fix": "npx lerna run lint-fix",
         "clean": "npx lerna exec -- rm -rf dist",
-        "publish-all": "npm run clean && npm run build && npx lerna publish from-package --dist-tag alpha"
+        "publish-all": "npm run clean && npm run build && npm run lint && npm test && npx lerna publish from-package --dist-tag alpha"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.0",

--- a/packages/event-store-postgres/package.json
+++ b/packages/event-store-postgres/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@dcb-es/event-store-postgres",
-    "description": "Postgres implementation of event store form @dcv-es/event-store",
+    "description": "Postgres implementation of event store for @dcb-es/event-store",
     "author": "Paul Grimshaw",
-    "license": "MIT",
-    "version": "6.2.1",
+    "license": "BSD-3-Clause",
+    "version": "7.0.0-alpha.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {
@@ -18,10 +18,10 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/sennentech/dcb-event-store.git"
+        "url": "git+https://github.com/kraken-tech/dcb-event-store.git"
     },
     "dependencies": {
-        "@dcb-es/event-store": "^5.1.3",
+        "@dcb-es/event-store": "^7.0.0-alpha.1",
         "pg": "^8.11.5",
         "pg-copy-streams": "^7.0.0"
     },

--- a/packages/event-store-postgres/package.json
+++ b/packages/event-store-postgres/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dcb-es/event-store-postgres",
-    "description": "Postgres implementation of event store for @dcb-es/event-store",
+    "description": "Postgres adapter for @dcb-es/event-store — persistent DCB event store with optimistic concurrency and tag-based querying",
     "author": "Paul Grimshaw",
     "license": "BSD-3-Clause",
     "version": "7.0.0-alpha.1",
@@ -16,10 +16,27 @@
         "lint-fix": "eslint \"**/*.ts\" . --fix",
         "prepare": "yarn build"
     },
+    "keywords": [
+        "event-sourcing",
+        "event-store",
+        "dcb",
+        "dynamic-consistency-boundary",
+        "postgres",
+        "cqrs",
+        "typescript"
+    ],
+    "homepage": "https://github.com/kraken-tech/dcb-event-store#readme",
+    "bugs": {
+        "url": "https://github.com/kraken-tech/dcb-event-store/issues"
+    },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/kraken-tech/dcb-event-store.git"
+        "url": "git+https://github.com/kraken-tech/dcb-event-store.git",
+        "directory": "packages/event-store-postgres"
     },
+    "files": [
+        "dist"
+    ],
     "dependencies": {
         "@dcb-es/event-store": "^7.0.0-alpha.1",
         "pg": "^8.11.5",
@@ -33,6 +50,5 @@
     },
     "publishConfig": {
         "access": "public"
-    },
-    "gitHead": "6c9a935d1d908d87be2207005acda8f3c9fa3926"
+    }
 }

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@dcb-es/event-store",
-    "version": "5.1.3",
+    "version": "7.0.0-alpha.1",
     "description": "Event Store package for DCB event sourced projects",
     "main": "dist/index.js",
-    "license": "MIT",
+    "license": "BSD-3-Clause",
     "types": "dist/index.d.ts",
     "scripts": {
         "test": "vitest run",
@@ -17,7 +17,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/sennentech/dcb-event-store.git"
+        "url": "git+https://github.com/kraken-tech/dcb-event-store.git"
     },
     "author": "Paul Grimshaw",
     "dependencies": {

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dcb-es/event-store",
     "version": "7.0.0-alpha.1",
-    "description": "Event Store package for DCB event sourced projects",
+    "description": "Dynamic Consistency Boundary (DCB) event store for TypeScript — in-memory implementation, decision models, and tag-based querying",
     "main": "dist/index.js",
     "license": "BSD-3-Clause",
     "types": "dist/index.d.ts",
@@ -15,11 +15,27 @@
         "lint-fix": "eslint \"**/*.ts\" . --fix",
         "prepare": "yarn build"
     },
+    "keywords": [
+        "event-sourcing",
+        "event-store",
+        "dcb",
+        "dynamic-consistency-boundary",
+        "cqrs",
+        "typescript"
+    ],
+    "homepage": "https://github.com/kraken-tech/dcb-event-store#readme",
+    "bugs": {
+        "url": "https://github.com/kraken-tech/dcb-event-store/issues"
+    },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/kraken-tech/dcb-event-store.git"
+        "url": "git+https://github.com/kraken-tech/dcb-event-store.git",
+        "directory": "packages/event-store"
     },
     "author": "Paul Grimshaw",
+    "files": [
+        "dist"
+    ],
     "dependencies": {
         "uuid": "^9.0.1"
     },
@@ -28,6 +44,5 @@
     },
     "publishConfig": {
         "access": "public"
-    },
-    "gitHead": "6c9a935d1d908d87be2207005acda8f3c9fa3926"
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Dynamic Consistency Boundary Event Store
+# Kraken DCB EventStore
 
 A TypeScript/Node.js implementation of the [Dynamic Consistency Boundary (DCB)](https://dcb.events) pattern. DCBs are a technique for enforcing consistency in event-driven systems without relying on rigid transactional boundaries -- establishing consistency requirements dynamically at runtime rather than at design time.
 


### PR DESCRIPTION
## Summary
- Align both published packages (`@dcb-es/event-store`, `@dcb-es/event-store-postgres`) to `7.0.0-alpha.1` under unified versioning
- Correct license fields from `MIT` to `BSD-3-Clause` across all package.json files
- Update repo URLs from `sennentech` to `kraken-tech`
- Fix description typo in event-store-postgres (`@dcv-es` → `@dcb-es`)
- Update README title to "Kraken DCB EventStore"

## Publish plan
After merge, publish from main with `--tag alpha`:
```
cd packages/event-store && npm publish --tag alpha
cd packages/event-store-postgres && npm publish --tag alpha
```

## Test plan
- [x] Build passes (all 4 packages)
- [x] Lint passes (all 4 packages)
- [x] All 351 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)