### PR TITLE
fix: exclude test fixture files from build output

### DIFF
--- a/packages/event-store-postgres/tsconfig.json
+++ b/packages/event-store-postgres/tsconfig.json
@@ -4,5 +4,5 @@
         "outDir": "./dist"
     },
     "include": ["src/**/*", "index.ts"],
-    "exclude": ["**/*.tests.ts"]
+    "exclude": ["**/*.tests.ts", "**/*.tests.*.ts"]
 }

--- a/packages/event-store/tsconfig.json
+++ b/packages/event-store/tsconfig.json
@@ -4,5 +4,5 @@
         "outDir": "./dist"
     },
     "include": ["src/**/*", "index.ts"],
-    "exclude": ["**/*.tests.ts"]
+    "exclude": ["**/*.tests.ts", "**/*.tests.*.ts"]
 }


### PR DESCRIPTION
## Summary
- Widen tsconfig `exclude` to also catch `*.tests.*.ts` patterns (e.g. `buildDecisionModel.tests.events.ts`)
- Prevents test fixture files from leaking into published `dist/` and npm tarballs

## Test plan
- [x] Clean build passes — no `*.tests.*` files in dist
- [x] All 351 tests still pass (vitest uses its own resolution, not tsconfig excludes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)