### PR TITLE
fix: replace broken lerna publish with npm workspace publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lint": "npx lerna run lint",
         "lint-fix": "npx lerna run lint-fix",
         "clean": "npx lerna exec -- rm -rf dist",
-        "publish-all": "npm run clean && npm run build && npm run lint && npm test && npx lerna publish from-package --dist-tag alpha"
+        "publish-all": "npm run clean && npm run build && npm run lint && npm test && npm publish --tag alpha -w packages/event-store && npm publish --tag alpha -w packages/event-store-postgres"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.0",


### PR DESCRIPTION
## Summary
- Lerna's `publish from-package` crashes on v8.2.4 (`Cannot read properties of undefined (reading 'create')`)
- Replace with `npm publish -w` using native workspace flag
- Pipeline unchanged: clean → build → lint → test → publish

## Test plan
- [x] Successfully published both packages to npm using `npm publish --tag alpha` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)