### PR TITLE
feat: event-store-bench + raise COPY_THRESHOLD to 10K

### DIFF
--- a/packages/event-store-bench/package.json
+++ b/packages/event-store-bench/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@dcb-es/event-store-bench",
+    "description": "Stress test and benchmark suite for all event store adapters",
+    "author": "Paul Grimshaw",
+    "license": "BSD-3-Clause",
+    "version": "0.1.0",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "test:pg": "vitest run -c vitest.pg.config.ts",
+        "test:pg-local": "vitest run -c vitest.pg-local.config.ts"
+    },
+    "devDependencies": {
+        "@dcb-es/event-store": "workspace:*",
+        "@dcb-es/event-store-postgres": "workspace:*",
+        "@testcontainers/postgresql": "^10.9.0",
+        "@types/pg": "^8.11.6",
+        "pg": "^8.11.5",
+        "testcontainers": "^10.9.0"
+    }
+}

--- a/packages/event-store-bench/src/harness/runner.tests.ts
+++ b/packages/event-store-bench/src/harness/runner.tests.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore, Tags, Query, AppendCommand } from "@dcb-es/event-store"
+import { runScenario } from "./runner"
+import { ScenarioConfig } from "./types"
+
+const simpleEventFactory = (workerId: number, _iteration: number) => [{
+    type: "TestEvent",
+    tags: Tags.fromObj({ test: `W${workerId}` }),
+    data: {},
+    metadata: {},
+}]
+
+describe("runScenario", () => {
+    it("single write worker completes", async () => {
+        const config: ScenarioConfig = {
+            name: "single-writer",
+            description: "one writer",
+            durationMs: 1000,
+            workers: [{ type: "write", count: 1, eventFactory: simpleEventFactory }],
+        }
+
+        const result = await runScenario(config, new MemoryEventStore())
+
+        expect(result.scenario).toBe("single-writer")
+        expect(result.workers).toHaveLength(1)
+        expect(result.workers[0].operations).toBeGreaterThan(0)
+        expect(result.workers[0].errors).toBe(0)
+    })
+
+    it("warmup excluded from measurements", async () => {
+        const config: ScenarioConfig = {
+            name: "warmup-test",
+            description: "warmup then measure",
+            warmupMs: 500,
+            durationMs: 1000,
+            workers: [{ type: "write", count: 1, eventFactory: simpleEventFactory }],
+        }
+
+        const result = await runScenario(config, new MemoryEventStore())
+
+        expect(result.durationMs).toBeGreaterThanOrEqual(900)
+        expect(result.workers[0].operations).toBeGreaterThan(0)
+    })
+
+    it("multiple workers run concurrently", async () => {
+        const config: ScenarioConfig = {
+            name: "multi-writer",
+            description: "five writers",
+            durationMs: 1000,
+            workers: [{ type: "write", count: 5, eventFactory: simpleEventFactory }],
+        }
+
+        const result = await runScenario(config, new MemoryEventStore())
+
+        expect(result.workers).toHaveLength(5)
+        for (const w of result.workers) {
+            expect(w.operations).toBeGreaterThan(0)
+        }
+    })
+
+    it("read worker works alongside write worker", async () => {
+        const config: ScenarioConfig = {
+            name: "read-write",
+            description: "writer and reader",
+            durationMs: 1000,
+            workers: [
+                { type: "write", count: 1, eventFactory: simpleEventFactory },
+                {
+                    type: "read",
+                    count: 1,
+                    queryFactory: () => Query.fromItems([
+                        { types: ["TestEvent"], tags: Tags.fromObj({ test: "W0" }) },
+                    ]),
+                },
+            ],
+        }
+
+        const result = await runScenario(config, new MemoryEventStore())
+
+        expect(result.workers).toHaveLength(2)
+        const readWorker = result.workers.find(w => w.type === "read")!
+        expect(readWorker.operations).toBeGreaterThan(0)
+        expect(readWorker.errors).toBe(0)
+    })
+
+    it("counts errors from failing append", async () => {
+        const store = new MemoryEventStore()
+        let appendCount = 0
+        const originalAppend = store.append.bind(store)
+        store.append = async (command: AppendCommand | AppendCommand[]) => {
+            appendCount++
+            if (appendCount % 3 === 0) throw new Error("boom")
+            return originalAppend(command)
+        }
+
+        const config: ScenarioConfig = {
+            name: "error-test",
+            description: "errors counted",
+            durationMs: 1000,
+            workers: [{ type: "write", count: 1, eventFactory: simpleEventFactory }],
+        }
+
+        const result = await runScenario(config, store)
+
+        expect(result.workers[0].errors).toBeGreaterThan(0)
+        expect(result.workers[0].operations).toBeGreaterThan(0)
+    })
+
+    it("import worker completes batches", async () => {
+        const config: ScenarioConfig = {
+            name: "import-test",
+            description: "batch import",
+            durationMs: 60_000,
+            workers: [{
+                type: "import",
+                count: 1,
+                totalEvents: 100,
+                batchSize: 25,
+                batchFactory: (workerId, batchIndex, batchSize) =>
+                    Array.from({ length: batchSize }, (_, i) => ({
+                        type: "ImportEvent",
+                        tags: Tags.fromObj({ batch: `${batchIndex}`, worker: `W${workerId}` }),
+                        data: { index: i },
+                        metadata: {},
+                    })),
+            }],
+        }
+
+        const result = await runScenario(config, new MemoryEventStore())
+
+        const importWorker = result.workers[0]
+        expect(importWorker.type).toBe("import")
+        expect(importWorker.operations).toBe(4)
+        expect(importWorker.events).toBe(100)
+        expect(importWorker.errors).toBe(0)
+    })
+})

--- a/packages/event-store-bench/src/harness/runner.ts
+++ b/packages/event-store-bench/src/harness/runner.ts
@@ -1,0 +1,205 @@
+import { EventStore, AppendConditionError, streamAllEventsToArray } from "@dcb-es/event-store"
+import {
+    ScenarioConfig,
+    ScenarioResult,
+    WorkerConfig,
+    WriteWorkerConfig,
+    ReadWorkerConfig,
+    ImportWorkerConfig,
+    WorkerResult,
+} from "./types"
+import { aggregateResults } from "./stats"
+
+export async function runScenario(
+    config: ScenarioConfig,
+    eventStore: EventStore,
+): Promise<ScenarioResult> {
+    const warmupMs = config.warmupMs ?? 0
+
+    const workerTasks: Array<{ config: WorkerConfig; workerId: number }> = []
+    let workerIdCounter = 0
+    for (const wc of config.workers) {
+        for (let i = 0; i < wc.count; i++) {
+            workerTasks.push({ config: wc, workerId: workerIdCounter++ })
+        }
+    }
+
+    const startTime = Date.now()
+    const endTime = startTime + warmupMs + config.durationMs
+
+    const workerPromises = workerTasks.map(({ config: wc, workerId }) =>
+        runWorker(wc, workerId, eventStore, startTime + warmupMs, endTime),
+    )
+
+    const workerResults = await Promise.all(workerPromises)
+
+    const actualDurationMs = Date.now() - startTime - warmupMs
+    const totalEvents = workerResults.reduce((sum, w) => {
+        return sum + (w.events > 0 ? w.events : w.operations)
+    }, 0)
+
+    return {
+        scenario: config.name,
+        description: config.description,
+        durationMs: actualDurationMs,
+        workers: workerResults,
+        aggregate: aggregateResults(workerResults, actualDurationMs, totalEvents),
+    }
+}
+
+async function runWorker(
+    config: WorkerConfig,
+    workerId: number,
+    eventStore: EventStore,
+    measureStart: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    switch (config.type) {
+        case "write":
+            return runWriteWorker(config, workerId, eventStore, measureStart, endTime)
+        case "read":
+            return runReadWorker(config, workerId, eventStore, measureStart, endTime)
+        case "import":
+            return runImportWorker(config, workerId, eventStore)
+    }
+}
+
+async function runWriteWorker(
+    config: WriteWorkerConfig,
+    workerId: number,
+    eventStore: EventStore,
+    measureStart: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId,
+        type: "write",
+        operations: 0,
+        events: 0,
+        errors: 0,
+        conflicts: 0,
+        latencies: [],
+    }
+
+    const intervalMs = config.targetRatePerSec
+        ? 1000 / config.targetRatePerSec
+        : 0
+
+    let iteration = 0
+    while (Date.now() < endTime) {
+        const events = config.eventFactory(workerId, iteration)
+        const condition = config.conditionFactory?.(workerId, iteration)
+
+        const opStart = Date.now()
+        try {
+            await eventStore.append({ events, condition })
+            const latency = Date.now() - opStart
+
+            if (Date.now() >= measureStart) {
+                result.operations++
+                result.events += events.length
+                result.latencies.push(latency)
+            }
+        } catch (err) {
+            if (err instanceof AppendConditionError) {
+                if (Date.now() >= measureStart) {
+                    result.conflicts++
+                }
+            } else {
+                if (Date.now() >= measureStart) {
+                    result.errors++
+                }
+            }
+        }
+
+        iteration++
+
+        if (intervalMs > 0) {
+            const elapsed = Date.now() - opStart
+            const sleepTime = intervalMs - elapsed
+            if (sleepTime > 0) await sleep(sleepTime)
+        }
+    }
+
+    return result
+}
+
+async function runReadWorker(
+    config: ReadWorkerConfig,
+    workerId: number,
+    eventStore: EventStore,
+    measureStart: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId,
+        type: "read",
+        operations: 0,
+        events: 0,
+        errors: 0,
+        conflicts: 0,
+        latencies: [],
+    }
+
+    let iteration = 0
+    while (Date.now() < endTime) {
+        const query = config.queryFactory(workerId, iteration)
+
+        const opStart = Date.now()
+        try {
+            await streamAllEventsToArray(eventStore.read(query, config.readOptions))
+            const latency = Date.now() - opStart
+
+            if (Date.now() >= measureStart) {
+                result.operations++
+                result.latencies.push(latency)
+            }
+        } catch {
+            if (Date.now() >= measureStart) {
+                result.errors++
+            }
+        }
+
+        iteration++
+    }
+
+    return result
+}
+
+async function runImportWorker(
+    config: ImportWorkerConfig,
+    workerId: number,
+    eventStore: EventStore,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId,
+        type: "import",
+        operations: 0,
+        events: 0,
+        errors: 0,
+        conflicts: 0,
+        latencies: [],
+    }
+
+    const totalBatches = Math.ceil(config.totalEvents / config.batchSize)
+    for (let batchIndex = 0; batchIndex < totalBatches; batchIndex++) {
+        const events = config.batchFactory(workerId, batchIndex, config.batchSize)
+
+        const opStart = Date.now()
+        try {
+            await eventStore.append({ events })
+            const latency = Date.now() - opStart
+            result.operations++
+            result.events += events.length
+            result.latencies.push(latency)
+        } catch {
+            result.errors++
+        }
+    }
+
+    return result
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/packages/event-store-bench/src/harness/stats.tests.ts
+++ b/packages/event-store-bench/src/harness/stats.tests.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest"
+import { computeLatencyStats, aggregateResults } from "./stats"
+
+describe("computeLatencyStats", () => {
+    it("returns zeros for empty array", () => {
+        const stats = computeLatencyStats([])
+        expect(stats).toEqual({ p50: 0, p95: 0, p99: 0, p999: 0, min: 0, max: 0, mean: 0 })
+    })
+
+    it("all percentiles equal single value", () => {
+        const stats = computeLatencyStats([42])
+        expect(stats.p50).toBe(42)
+        expect(stats.p95).toBe(42)
+        expect(stats.p99).toBe(42)
+        expect(stats.min).toBe(42)
+        expect(stats.max).toBe(42)
+        expect(stats.mean).toBe(42)
+    })
+
+    it("known distribution 1..100", () => {
+        const latencies = Array.from({ length: 100 }, (_, i) => i + 1)
+        const stats = computeLatencyStats(latencies)
+
+        expect(stats.min).toBe(1)
+        expect(stats.max).toBe(100)
+        expect(stats.p50).toBe(50)
+        expect(stats.p95).toBe(95)
+        expect(stats.p99).toBe(99)
+        expect(stats.mean).toBe(51)
+    })
+})
+
+describe("aggregateResults", () => {
+    it("combines multiple workers correctly", () => {
+        const workers = [
+            { workerId: 0, type: "write" as const, operations: 100, events: 100, errors: 2, conflicts: 1, latencies: [10, 20] },
+            { workerId: 1, type: "write" as const, operations: 200, events: 200, errors: 3, conflicts: 0, latencies: [15, 25] },
+            { workerId: 2, type: "write" as const, operations: 50, events: 50, errors: 0, conflicts: 5, latencies: [5, 30] },
+        ]
+
+        const result = aggregateResults(workers, 10_000, 350)
+
+        expect(result.totalOperations).toBe(350)
+        expect(result.totalErrors).toBe(5)
+        expect(result.totalConflicts).toBe(6)
+        expect(result.opsPerSec).toBe(35)
+        expect(result.eventsPerSec).toBe(35)
+        expect(result.latency.min).toBe(5)
+        expect(result.latency.max).toBe(30)
+    })
+})

--- a/packages/event-store-bench/src/harness/stats.ts
+++ b/packages/event-store-bench/src/harness/stats.ts
@@ -1,0 +1,54 @@
+import { LatencyStats, WorkerResult, AggregateMetrics } from "./types"
+
+export function computeLatencyStats(latencies: number[]): LatencyStats {
+    if (latencies.length === 0) {
+        return { p50: 0, p95: 0, p99: 0, p999: 0, min: 0, max: 0, mean: 0 }
+    }
+
+    const sorted = [...latencies].sort((a, b) => a - b)
+    const sum = sorted.reduce((a, b) => a + b, 0)
+
+    return {
+        p50: percentile(sorted, 0.50),
+        p95: percentile(sorted, 0.95),
+        p99: percentile(sorted, 0.99),
+        p999: percentile(sorted, 0.999),
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+        mean: Math.round(sum / sorted.length),
+    }
+}
+
+export function aggregateResults(
+    workers: WorkerResult[],
+    durationMs: number,
+    totalEvents: number,
+): AggregateMetrics {
+    const allLatencies: number[] = []
+    let totalOperations = 0
+    let totalErrors = 0
+    let totalConflicts = 0
+
+    for (const w of workers) {
+        totalOperations += w.operations
+        totalErrors += w.errors
+        totalConflicts += w.conflicts
+        for (const l of w.latencies) allLatencies.push(l)
+    }
+
+    const durationSec = durationMs / 1000
+
+    return {
+        totalOperations,
+        totalErrors,
+        totalConflicts,
+        opsPerSec: Math.round(totalOperations / durationSec),
+        eventsPerSec: Math.round(totalEvents / durationSec),
+        latency: computeLatencyStats(allLatencies),
+    }
+}
+
+function percentile(sorted: number[], p: number): number {
+    const index = Math.ceil(p * sorted.length) - 1
+    return sorted[Math.max(0, index)]
+}

--- a/packages/event-store-bench/src/harness/types.ts
+++ b/packages/event-store-bench/src/harness/types.ts
@@ -1,0 +1,92 @@
+import { DcbEvent, AppendCondition, Query, ReadOptions, EventStore } from "@dcb-es/event-store"
+
+// ─── Factory ───────────────────────────────────────────────────────
+
+export type EventStoreFactory = (runId: string) => EventStore | Promise<EventStore>
+
+export type ThresholdFactory = (runId: string, copyThreshold: number) => EventStore | Promise<EventStore>
+
+// ─── Scenario Configuration ─────────────────────────────────────────
+
+export interface ScenarioConfig {
+    name: string
+    description: string
+    workers: WorkerConfig[]
+    durationMs: number
+    warmupMs?: number
+}
+
+export type WorkerConfig = WriteWorkerConfig | ReadWorkerConfig | ImportWorkerConfig
+
+export interface WriteWorkerConfig {
+    type: "write"
+    count: number
+    eventFactory: EventFactory
+    conditionFactory?: ConditionFactory
+    targetRatePerSec?: number
+}
+
+export interface ReadWorkerConfig {
+    type: "read"
+    count: number
+    queryFactory: QueryFactory
+    readOptions?: ReadOptions
+}
+
+export interface ImportWorkerConfig {
+    type: "import"
+    count: number
+    batchFactory: BatchFactory
+    totalEvents: number
+    batchSize: number
+}
+
+// ─── Factories ──────────────────────────────────────────────────────
+
+export type EventFactory = (workerId: number, iteration: number) => DcbEvent[]
+
+export type ConditionFactory = (workerId: number, iteration: number) => AppendCondition | undefined
+
+export type QueryFactory = (workerId: number, iteration: number) => Query
+
+export type BatchFactory = (workerId: number, batchIndex: number, batchSize: number) => DcbEvent[]
+
+// ─── Results ────────────────────────────────────────────────────────
+
+export interface ScenarioResult {
+    scenario: string
+    description: string
+    durationMs: number
+    workers: WorkerResult[]
+    aggregate: AggregateMetrics
+}
+
+export interface WorkerResult {
+    workerId: number
+    type: "write" | "read" | "import"
+    operations: number
+    events: number
+    errors: number
+    conflicts: number
+    latencies: number[]
+}
+
+export interface AggregateMetrics {
+    totalOperations: number
+    totalErrors: number
+    totalConflicts: number
+    opsPerSec: number
+    eventsPerSec: number
+    latency: LatencyStats
+}
+
+export interface LatencyStats {
+    p50: number
+    p95: number
+    p99: number
+    p999: number
+    min: number
+    max: number
+    mean: number
+}
+

--- a/packages/event-store-bench/src/pg-local.tests.ts
+++ b/packages/event-store-bench/src/pg-local.tests.ts
@@ -1,0 +1,434 @@
+import { Pool, Client } from "pg"
+import { v4 as uuid } from "uuid"
+import { PostgresEventStore } from "@dcb-es/event-store-postgres"
+import { EventStore } from "@dcb-es/event-store"
+import { EventStoreFactory, ThresholdFactory } from "./harness/types"
+import { formatScenarioResult } from "./reporters/tableReporter"
+
+import { run as runT1 } from "./scenarios/t1-throughput"
+import { run as runT2 } from "./scenarios/t2-bulk-import"
+import { run as runT3 } from "./scenarios/t3-contention"
+import { run as runT5 } from "./scenarios/t5-raw-throughput"
+import { run as runT8 } from "./scenarios/t8-consistency"
+import { run as runT9 } from "./scenarios/t9-overlap-consistency"
+import { run as runT4 } from "./scenarios/t4-mixed-workload"
+import { run as runT6 } from "./scenarios/t6-parallel-import"
+import { run as runT10 } from "./scenarios/t10-esb-compat"
+import { run as runT11 } from "./scenarios/t11-meter-upsert"
+import { run as runT12 } from "./scenarios/t12-batch-throughput"
+import { run as runT13 } from "./scenarios/t13-degradation"
+import { run as runT14 } from "./scenarios/t14-copy-threshold"
+import { run as runT15 } from "./scenarios/t15-copy-crossover"
+import { run as runT16 } from "./scenarios/t16-batch-commands"
+
+const BASE_URI = process.env.PG_CONNECTION_STRING ?? "postgresql://localhost:5432/postgres"
+
+async function pgAvailable(): Promise<boolean> {
+    const client = new Client({ connectionString: BASE_URI })
+    try {
+        await client.connect()
+        await client.end()
+        return true
+    } catch {
+        return false
+    }
+}
+
+async function createTestDb(): Promise<{ connectionString: string; dbName: string }> {
+    const dbName = `bench_${uuid().split("-").join("").slice(0, 16)}`
+    const client = new Client({ connectionString: BASE_URI })
+    await client.connect()
+    await client.query(`CREATE DATABASE "${dbName}"`)
+    await client.end()
+
+    const url = new URL(BASE_URI)
+    url.pathname = `/${dbName}`
+    return { connectionString: url.toString(), dbName }
+}
+
+async function dropTestDb(dbName: string): Promise<void> {
+    const client = new Client({ connectionString: BASE_URI })
+    await client.connect()
+    await client.query(`DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE)`)
+    await client.end()
+}
+
+function createBenchPool(connectionString: string, max: number): Pool {
+    const pool = new Pool({ connectionString, max })
+    // Set synchronous_commit=off on every connection for benchmark throughput.
+    // Safe for event stores with replay capability — only risks last few ms on hard crash.
+    pool.on("connect", (client: Client) => {
+        client.query("SET synchronous_commit = off")
+    })
+    return pool
+}
+
+function createPgFactory(pool: Pool, isolated = false): EventStoreFactory {
+    return async (runId: string): Promise<EventStore> => {
+        const tablePrefix = isolated ? runId.replace(/[^a-z0-9_]/gi, "_").slice(0, 40) : undefined
+        const store = new PostgresEventStore({ pool, tablePrefix })
+        await store.ensureInstalled()
+        return store
+    }
+}
+
+describe("stress — local postgres", async () => {
+    const available = await pgAvailable()
+
+    beforeAll(() => {
+        if (!available) {
+            console.log(`Skipping local PG tests — cannot connect to ${BASE_URI}`)
+        }
+    })
+
+    test.skipIf(!available)("T1 — throughput baseline (1/5/10 writers, 10s each)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT1(factory, [
+                { name: "1-writer", workers: 1, durationMs: 10_000 },
+                { name: "5-writers", workers: 5, durationMs: 10_000 },
+                { name: "10-writers", workers: 10, durationMs: 10_000 },
+            ])
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.verification?.checks.find(c => c.name === "zero-errors")?.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T2 — bulk import 10K meters (110K events)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 20)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT2(factory, { meterCount: 20_000, metersPerChunk: 2_500 })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.verification?.checks.find(c => c.name === "total-event-count")?.pass).toBe(true)
+            expect(result.verification?.checks.find(c => c.name === "no-duplicate-creates")?.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T3 — contention (20 workers, 10s)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT3(factory, { workerCount: 20, durationMs: 10_000 })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.scenarios[0].aggregate.totalErrors).toBe(0)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T5 — raw bulk throughput (250K events)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 20)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT5(factory, { eventCount: 250_000 })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.verification?.checks.find(c => c.name === "event-count")?.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T8 — consistency oracle (20 workers, 200 entities, 10s)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT8(factory, { entityCount: 200, workerCount: 20, durationMs: 10_000 })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.verification?.checks.find(c => c.name === "zero-duplicates")?.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T9 — overlapping scope consistency (10 workers, 50 entities, 10s)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT9(factory, { entityCount: 50, workerCount: 10, durationMs: 10_000 })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.verification?.checks.find(c => c.name === "zero-duplicates")?.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T4 — mixed workload (import + 5 small writers, 10s)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT4(factory, {
+                importTotalEvents: 5_000,
+                importBatchSize: 500,
+                importConcurrency: 2,
+                smallWriterCount: 5,
+                smallWriteRatePerSec: 10,
+                durationMs: 10_000,
+            })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.verification?.checks.find(c => c.name === "import-completed")?.pass).toBe(true)
+            expect(result.verification?.checks.find(c => c.name === "small-writer-zero-errors")?.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T6 — parallel bulk import (5 batches x 100 meters)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT6(factory, { batchCount: 5, metersPerBatch: 100 })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.verification?.checks.find(c => c.name === "all-batches-completed")?.pass).toBe(true)
+            expect(result.verification?.checks.find(c => c.name === "no-duplicate-creates")?.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T10 — ESB-compat benchmark (1/2/4 writers, 1/2/4 readers, 5s each)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const tiers = [
+                { name: "1", workers: 1, durationMs: 5_000 },
+                { name: "2", workers: 2, durationMs: 5_000 },
+                { name: "4", workers: 4, durationMs: 5_000 },
+            ]
+            const result = await runT10(factory, { writeTiers: tiers, readTiers: tiers })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T11 — meter upsert (300 meters)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 20)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT11(factory, { totalMeters: 300 })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.verification?.checks.find(c => c.name === "all-meters-alive")?.pass).toBe(true)
+            expect(result.verification?.checks.find(c => c.name === "no-duplicate-creates")?.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 120_000)
+
+    test.skipIf(!available)("T12 — batch throughput sweep (unconditional, 10 workers)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT12(factory, {
+                workerCount: 10,
+                batchSizes: [1, 10, 50, 100, 500],
+                durationPerTierMs: 15_000,
+                conditional: false,
+            })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 600_000)
+
+    test.skipIf(!available)("T12 — batch throughput sweep (conditional, 10 workers)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT12(factory, {
+                workerCount: 10,
+                batchSizes: [1, 10, 50, 100, 500],
+                durationPerTierMs: 15_000,
+                conditional: true,
+            })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 600_000)
+
+    test.skipIf(!available)("T13 — degradation (batch-500, conditional, 4 phases x 30s)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool)
+            const result = await runT13(factory, {
+                workerCount: 10,
+                batchSize: 500,
+                phases: 4,
+                durationPerPhaseMs: 30_000,
+                conditional: true,
+            })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            if (result.verification) {
+                for (const c of result.verification.checks) {
+                    console.log(`  ${c.name}: ${c.actual}`)
+                }
+            }
+
+            expect(result.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 600_000)
+
+    test.skipIf(!available)("T14 — copy threshold sweep (batch=500, unconditional)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const thresholdFactory: ThresholdFactory = async (_runId, copyThreshold) => {
+                const store = new PostgresEventStore({ pool, copyThreshold })
+                await store.ensureInstalled()
+                return store
+            }
+            const result = await runT14(thresholdFactory, {
+                workerCount: 10,
+                batchSize: 500,
+                thresholds: [10, 100, 250, 500, 1000, 2500],
+                durationPerTierMs: 15_000,
+            })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 600_000)
+
+    test.skipIf(!available)("T15 — copy vs function crossover", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const thresholdFactory: ThresholdFactory = async (_runId, copyThreshold) => {
+                const store = new PostgresEventStore({ pool, copyThreshold })
+                await store.ensureInstalled()
+                return store
+            }
+            const result = await runT15(thresholdFactory, {
+                workerCount: 10,
+                batchSizes: [1000, 5000, 10000, 25000, 50000],
+                durationPerTierMs: 10_000,
+            })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 600_000)
+
+    test.skipIf(!available)("T16 — batch commands (1/10/50/100/500 cmds per append, each with condition)", async () => {
+        const { connectionString, dbName } = await createTestDb()
+        const pool = createBenchPool(connectionString, 50)
+        try {
+            const factory = createPgFactory(pool, true)
+            const result = await runT16(factory, {
+                workerCount: 10,
+                commandsPerAppend: [1, 10, 50, 100, 500],
+                durationPerTierMs: 15_000,
+            })
+
+            for (const s of result.scenarios) {
+                console.log(formatScenarioResult(s))
+            }
+
+            expect(result.pass).toBe(true)
+        } finally {
+            await pool.end()
+            await dropTestDb(dbName)
+        }
+    }, 600_000)
+})

--- a/packages/event-store-bench/src/pg.tests.ts
+++ b/packages/event-store-bench/src/pg.tests.ts
@@ -1,0 +1,166 @@
+import { Pool } from "pg"
+import { PostgresEventStore } from "@dcb-es/event-store-postgres"
+import { EventStore } from "@dcb-es/event-store"
+import { getTestPgDatabasePool } from "@test/testPgDbPool"
+import { EventStoreFactory } from "./harness/types"
+import { formatScenarioResult } from "./reporters/tableReporter"
+
+import { run as runT1 } from "./scenarios/t1-throughput"
+import { run as runT2 } from "./scenarios/t2-bulk-import"
+import { run as runT3 } from "./scenarios/t3-contention"
+import { run as runT5 } from "./scenarios/t5-raw-throughput"
+import { run as runT6 } from "./scenarios/t6-parallel-import"
+import { run as runT8 } from "./scenarios/t8-consistency"
+import { run as runT9 } from "./scenarios/t9-overlap-consistency"
+import { run as runT4 } from "./scenarios/t4-mixed-workload"
+import { run as runT10 } from "./scenarios/t10-esb-compat"
+import { run as runT11 } from "./scenarios/t11-meter-upsert"
+
+function createPgFactory(pool: Pool): EventStoreFactory {
+    return async (_runId: string): Promise<EventStore> => {
+        const store = new PostgresEventStore({ pool })
+        await store.ensureInstalled()
+        return store
+    }
+}
+
+describe("stress — postgres (testcontainers)", () => {
+    let pool: Pool
+
+    beforeAll(async () => {
+        pool = await getTestPgDatabasePool({ max: 50 })
+    })
+
+    afterAll(async () => {
+        if (pool) await pool.end()
+    })
+
+    test("T1 — throughput baseline (1/5 writers, 5s each)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT1(factory, [
+            { name: "1-writer", workers: 1, durationMs: 5_000 },
+            { name: "5-writers", workers: 5, durationMs: 5_000 },
+        ])
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.verification?.checks.find(c => c.name === "zero-errors")?.pass).toBe(true)
+    }, 120_000)
+
+    test("T2 — bulk import 100 meters with conditions (1100 events)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT2(factory, { meterCount: 100, metersPerChunk: 50 })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.verification?.checks.find(c => c.name === "total-event-count")?.pass).toBe(true)
+        expect(result.verification?.checks.find(c => c.name === "no-duplicate-creates")?.pass).toBe(true)
+    }, 120_000)
+
+    test("T3 — contention (5 workers, 5s)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT3(factory, { workerCount: 5, durationMs: 5_000 })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.scenarios[0].aggregate.totalErrors).toBe(0)
+        expect(result.verification?.checks.find(c => c.name === "event-count-matches-appends")?.pass).toBe(true)
+    }, 120_000)
+
+    test("T5 — raw bulk throughput (10K events)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT5(factory, { eventCount: 10_000 })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.verification?.checks.find(c => c.name === "event-count")?.pass).toBe(true)
+    }, 120_000)
+
+    test("T8 — consistency oracle (5 workers, 20 entities, 5s)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT8(factory, { entityCount: 20, workerCount: 5, durationMs: 5_000 })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.verification?.checks.find(c => c.name === "zero-duplicates")?.pass).toBe(true)
+    }, 120_000)
+
+    test("T9 — overlapping scope consistency (5 workers, 20 entities, 5s)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT9(factory, { entityCount: 20, workerCount: 5, durationMs: 5_000 })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.verification?.checks.find(c => c.name === "zero-duplicates")?.pass).toBe(true)
+    }, 120_000)
+
+    test("T4 — mixed workload (import + 3 small writers, 5s)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT4(factory, {
+            importTotalEvents: 1_000,
+            importBatchSize: 250,
+            importConcurrency: 2,
+            smallWriterCount: 3,
+            smallWriteRatePerSec: 10,
+            durationMs: 5_000,
+        })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.verification?.checks.find(c => c.name === "import-completed")?.pass).toBe(true)
+        expect(result.verification?.checks.find(c => c.name === "small-writer-zero-errors")?.pass).toBe(true)
+    }, 120_000)
+
+    test("T6 — parallel bulk import (3 batches x 50 meters)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT6(factory, { batchCount: 3, metersPerBatch: 50 })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.verification?.checks.find(c => c.name === "all-batches-completed")?.pass).toBe(true)
+        expect(result.verification?.checks.find(c => c.name === "no-duplicate-creates")?.pass).toBe(true)
+    }, 120_000)
+
+    test("T10 — ESB-compat benchmark (1/2 writers, 1/2 readers, 3s each)", async () => {
+        const factory = createPgFactory(pool)
+        const tiers = [
+            { name: "1", workers: 1, durationMs: 3_000 },
+            { name: "2", workers: 2, durationMs: 3_000 },
+        ]
+        const result = await runT10(factory, { writeTiers: tiers, readTiers: tiers })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.pass).toBe(true)
+    }, 120_000)
+
+    test("T11 — meter upsert (90 meters)", async () => {
+        const factory = createPgFactory(pool)
+        const result = await runT11(factory, { totalMeters: 90 })
+
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+
+        expect(result.verification?.checks.find(c => c.name === "all-meters-alive")?.pass).toBe(true)
+        expect(result.verification?.checks.find(c => c.name === "no-duplicate-creates")?.pass).toBe(true)
+    }, 120_000)
+})

--- a/packages/event-store-bench/src/reporters/jsonReporter.ts
+++ b/packages/event-store-bench/src/reporters/jsonReporter.ts
@@ -1,0 +1,22 @@
+import { ScenarioResult } from "../harness/types"
+
+export function toJsonReport(results: ScenarioResult[]): string {
+    const report = {
+        timestamp: new Date().toISOString(),
+        results: results.map(r => ({
+            scenario: r.scenario,
+            description: r.description,
+            durationMs: r.durationMs,
+            aggregate: r.aggregate,
+            workers: r.workers.map(w => ({
+                workerId: w.workerId,
+                type: w.type,
+                operations: w.operations,
+                errors: w.errors,
+                conflicts: w.conflicts,
+                latencyCount: w.latencies.length,
+            })),
+        })),
+    }
+    return JSON.stringify(report, null, 2)
+}

--- a/packages/event-store-bench/src/reporters/tableReporter.ts
+++ b/packages/event-store-bench/src/reporters/tableReporter.ts
@@ -1,0 +1,71 @@
+import { ScenarioResult, LatencyStats } from "../harness/types"
+
+export function formatScenarioResult(result: ScenarioResult): string {
+    const lines: string[] = []
+
+    lines.push("")
+    lines.push("=".repeat(72))
+    lines.push(`  ${result.scenario}`)
+    lines.push(`  ${result.description}`)
+    lines.push("=".repeat(72))
+    lines.push("")
+
+    const a = result.aggregate
+    lines.push("  Aggregate Metrics")
+    lines.push("  " + "-".repeat(50))
+    lines.push(formatRow("Duration", `${(result.durationMs / 1000).toFixed(1)}s`))
+    lines.push(formatRow("Total operations", String(a.totalOperations)))
+    lines.push(formatRow("Ops/sec", String(a.opsPerSec)))
+    lines.push(formatRow("Events/sec", String(a.eventsPerSec)))
+    lines.push(formatRow("Errors", String(a.totalErrors)))
+    lines.push(formatRow("Conflicts", String(a.totalConflicts)))
+    lines.push("")
+
+    lines.push("  Latency (ms)")
+    lines.push("  " + "-".repeat(50))
+    lines.push(formatLatencyTable(a.latency))
+    lines.push("")
+
+    if (result.workers.length > 1) {
+        lines.push("  Per-Worker Breakdown")
+        lines.push("  " + "-".repeat(50))
+        lines.push(formatWorkerHeader())
+        for (const w of result.workers) {
+            lines.push(formatWorkerRow(w))
+        }
+        lines.push("")
+    }
+
+    return lines.join("\n")
+}
+
+export function formatMultipleResults(results: ScenarioResult[]): string {
+    return results.map(formatScenarioResult).join("\n")
+}
+
+function formatRow(label: string, value: string): string {
+    return `  ${label.padEnd(24)} ${value}`
+}
+
+function formatLatencyTable(stats: LatencyStats): string {
+    const lines: string[] = []
+    lines.push(formatRow("min", `${stats.min}ms`))
+    lines.push(formatRow("p50", `${stats.p50}ms`))
+    lines.push(formatRow("p95", `${stats.p95}ms`))
+    lines.push(formatRow("p99", `${stats.p99}ms`))
+    lines.push(formatRow("p99.9", `${stats.p999}ms`))
+    lines.push(formatRow("max", `${stats.max}ms`))
+    lines.push(formatRow("mean", `${stats.mean}ms`))
+    return lines.join("\n")
+}
+
+function formatWorkerHeader(): string {
+    return `  ${"ID".padEnd(6)}${"Type".padEnd(10)}${"Ops".padEnd(10)}${"Err".padEnd(8)}${"Conf".padEnd(8)}${"p50".padEnd(8)}${"p99".padEnd(8)}`
+}
+
+function formatWorkerRow(w: { workerId: number; type: string; operations: number; errors: number; conflicts: number; latencies: number[] }): string {
+    const sorted = [...w.latencies].sort((a, b) => a - b)
+    const p50 = sorted.length > 0 ? sorted[Math.ceil(0.5 * sorted.length) - 1] : 0
+    const p99 = sorted.length > 0 ? sorted[Math.ceil(0.99 * sorted.length) - 1] : 0
+    return `  ${String(w.workerId).padEnd(6)}${w.type.padEnd(10)}${String(w.operations).padEnd(10)}${String(w.errors).padEnd(8)}${String(w.conflicts).padEnd(8)}${String(p50).padEnd(8)}${String(p99).padEnd(8)}`
+}

--- a/packages/event-store-bench/src/scenarios/factories.ts
+++ b/packages/event-store-bench/src/scenarios/factories.ts
@@ -1,0 +1,170 @@
+import { DcbEvent, AppendCommand, Tags, Query, SequencePosition, AppendCondition } from "@dcb-es/event-store"
+
+// ─── T1: Throughput Baseline ────────────────────────────────────────
+
+export function t1EventFactory(workerId: number): DcbEvent[] {
+    return [{
+        type: "EntityCreated",
+        tags: Tags.fromObj({ entity: `W${workerId}` }),
+        data: { workerId, ts: Date.now() },
+        metadata: {},
+    }]
+}
+
+export function t1QueryFactory(workerId: number): Query {
+    return Query.fromItems([{ types: ["EntityCreated"], tags: Tags.fromObj({ entity: `W${workerId}` }) }])
+}
+
+// ─── T3: Contention Gauntlet ────────────────────────────────────────
+
+export function t3EventFactory(_workerId: number): DcbEvent[] {
+    return [{
+        type: "ThingCreated",
+        tags: Tags.fromObj({ thing: "CONTESTED" }),
+        data: { ts: Date.now() },
+        metadata: {},
+    }]
+}
+
+export function t3QueryFactory(_workerId: number): Query {
+    return Query.fromItems([{ types: ["ThingCreated"], tags: Tags.fromObj({ thing: "CONTESTED" }) }])
+}
+
+// ─── T4: Mixed Workload — Import phase ──────────────────────────────
+
+export function t4ImportBatchFactory(_workerId: number, batchIndex: number, batchSize: number): DcbEvent[] {
+    const events: DcbEvent[] = []
+    const startIndex = batchIndex * batchSize
+    for (let i = 0; i < batchSize; i++) {
+        const n = startIndex + i + 1
+        events.push({
+            type: "MeterCreated",
+            tags: Tags.fromObj({ meter: `A${n}` }),
+            data: { meterIndex: n },
+            metadata: {},
+        })
+    }
+    return events
+}
+
+// ─── T4: Mixed Workload — Small writes ──────────────────────────────
+
+export function t4SmallWriteEventFactory(workerId: number): DcbEvent[] {
+    return [{
+        type: "OrderPlaced",
+        tags: Tags.fromObj({ order: `B${workerId}` }),
+        data: { workerId, ts: Date.now() },
+        metadata: {},
+    }]
+}
+
+export function t4SmallWriteQueryFactory(workerId: number): Query {
+    return Query.fromItems([{ types: ["OrderPlaced"], tags: Tags.fromObj({ order: `B${workerId}` }) }])
+}
+
+// ─── Meter Import (shared by T2, T6) ────────────────────────────────
+
+export const EVENTS_PER_METER = 11
+
+const METER_FIELD_EVENTS = [
+    "FirmwareVersionSet",
+    "LocationSet",
+    "CommissionDateSet",
+    "TariffAssigned",
+    "NetworkJoined",
+    "InitialReadingSet",
+    "CalibrationRecorded",
+    "ActivationCompleted",
+    "MeterReady",
+] as const
+
+export function buildMeterCommands(meterStart: number, meterEnd: number): AppendCommand[] {
+    const commands: AppendCommand[] = []
+
+    for (let m = meterStart; m < meterEnd; m++) {
+        const meterId = `M${String(m + 1).padStart(5, "0")}`
+        const serialNumber = `SN${String(m + 1).padStart(8, "0")}`
+
+        commands.push({
+            events: [{
+                type: "MeterCreated",
+                tags: Tags.fromObj({ meterId }),
+                data: { meterId, serialNumber },
+                metadata: {},
+            }],
+            condition: {
+                failIfEventsMatch: Query.fromItems([
+                    { types: ["MeterCreated"], tags: Tags.fromObj({ meterId }) },
+                ]),
+                after: SequencePosition.initial(),
+            },
+        })
+
+        commands.push({
+            events: [{
+                type: "SerialNumberSet",
+                tags: Tags.fromObj({ meterId, serialNumber }),
+                data: { meterId, serialNumber },
+                metadata: {},
+            }],
+            condition: {
+                failIfEventsMatch: Query.fromItems([
+                    { types: ["SerialNumberSet"], tags: Tags.fromObj({ meterId, serialNumber }) },
+                ]),
+                after: SequencePosition.initial(),
+            },
+        })
+
+        const fieldEvents: DcbEvent[] = METER_FIELD_EVENTS.map(type => ({
+            type,
+            tags: Tags.fromObj(
+                type === "InitialReadingSet" ? { meterId, serialNumber } : { meterId },
+            ),
+            data: { meterId, serialNumber, field: type },
+            metadata: {},
+        }))
+
+        commands.push({ events: fieldEvents })
+    }
+
+    return commands
+}
+
+// ─── T8: Consistency Oracle ─────────────────────────────────────────
+
+export function t8EventFactory(workerId: number, entityIndex: number): DcbEvent[] {
+    const padded = String(entityIndex).padStart(3, "0")
+    return [{
+        type: "EntityCreated",
+        tags: Tags.fromObj({ entity: `E${padded}` }),
+        data: { workerId, entityIndex, ts: Date.now() },
+        metadata: {},
+    }]
+}
+
+export function t8QueryFactory(entityIndex: number): Query {
+    const padded = String(entityIndex).padStart(3, "0")
+    return Query.fromItems([{ types: ["EntityCreated"], tags: Tags.fromObj({ entity: `E${padded}` }) }])
+}
+
+// ─── T9: Overlapping Scope Consistency ──────────────────────────────
+
+export function t9EventFactory(workerId: number, entityIndex: number): DcbEvent[] {
+    const padded = String(entityIndex).padStart(3, "0")
+    return [{
+        type: "EntityRegistered",
+        tags: Tags.fromObj({ entity: `E${padded}`, worker: `W${workerId}` }),
+        data: { workerId, entityIndex, ts: Date.now() },
+        metadata: {},
+    }]
+}
+
+export function t9ConditionQuery(entityIndex: number): Query {
+    const padded = String(entityIndex).padStart(3, "0")
+    return Query.fromItems([{ types: ["EntityRegistered"], tags: Tags.fromObj({ entity: `E${padded}` }) }])
+}
+
+export function t9ReadQuery(entityIndex: number): Query {
+    const padded = String(entityIndex).padStart(3, "0")
+    return Query.fromItems([{ types: ["EntityRegistered"], tags: Tags.fromObj({ entity: `E${padded}` }) }])
+}

--- a/packages/event-store-bench/src/scenarios/helpers.ts
+++ b/packages/event-store-bench/src/scenarios/helpers.ts
@@ -1,0 +1,127 @@
+import {
+    EventStore,
+    AppendConditionError,
+    Query,
+    DcbEvent,
+    SequencePosition,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+import { StressTestResult, VerificationResult } from "./stressTypes"
+
+// ─── DCB Conditional Retry Worker ───────────────────────────────────
+
+export async function conditionalRetryWorker(
+    eventStore: EventStore,
+    scopeQuery: Query,
+    eventFactory: (workerId: number) => DcbEvent[],
+    workerId: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    let lastPosition: SequencePosition | undefined
+
+    while (Date.now() < endTime) {
+        try {
+            if (lastPosition === undefined) {
+                const [latest] = await streamAllEventsToArray(
+                    eventStore.read(scopeQuery, { backwards: true, limit: 1 }),
+                )
+                lastPosition = latest?.position ?? SequencePosition.initial()
+            }
+
+            const events = eventFactory(workerId)
+            const condition = { failIfEventsMatch: scopeQuery, after: lastPosition }
+
+            const opStart = Date.now()
+            lastPosition = await eventStore.append({ events, condition })
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += events.length
+        } catch (err) {
+            if (err instanceof AppendConditionError) {
+                result.conflicts++
+                lastPosition = undefined
+            } else {
+                result.errors++
+            }
+        }
+    }
+
+    return result
+}
+
+// ─── Verification Helpers ───────────────────────────────────────────
+
+export async function verifyEventCount(
+    eventStore: EventStore,
+    query: Query,
+    expected: number,
+): Promise<{ name: string; expected: string; actual: string; pass: boolean }> {
+    const events = await streamAllEventsToArray(eventStore.read(query))
+    return {
+        name: "event-count",
+        expected: String(expected),
+        actual: String(events.length),
+        pass: events.length === expected,
+    }
+}
+
+export async function verifyNoDuplicates(
+    eventStore: EventStore,
+    query: Query,
+    keyExtractor: (event: DcbEvent) => string,
+): Promise<{ name: string; expected: string; actual: string; pass: boolean }> {
+    const events = await streamAllEventsToArray(eventStore.read(query))
+    const keys = events.map(e => keyExtractor(e.event))
+    const uniqueKeys = new Set(keys)
+    const duplicateCount = keys.length - uniqueKeys.size
+    return {
+        name: "no-duplicates",
+        expected: "0",
+        actual: String(duplicateCount),
+        pass: duplicateCount === 0,
+    }
+}
+
+export function verifyAllWorkersProgressed(
+    workers: WorkerResult[],
+): { name: string; expected: string; actual: string; pass: boolean } {
+    const stalled = workers.filter(w => w.operations === 0)
+    return {
+        name: "all-workers-progressed",
+        expected: "0 stalled",
+        actual: `${stalled.length} stalled`,
+        pass: stalled.length === 0,
+    }
+}
+
+// ─── Tiered Scenario Runner ─────────────────────────────────────────
+
+export interface TierConfig {
+    name: string
+    workers: number
+    durationMs: number
+}
+
+export async function runTieredScenario(
+    id: string,
+    name: string,
+    tiers: TierConfig[],
+    runTier: (tier: TierConfig) => Promise<ScenarioResult>,
+    verify?: () => Promise<VerificationResult>,
+): Promise<StressTestResult> {
+    const scenarios: ScenarioResult[] = []
+    for (const tier of tiers) {
+        const result = await runTier(tier)
+        scenarios.push(result)
+    }
+    const verification = verify ? await verify() : undefined
+    const pass = scenarios.every(s => s.aggregate.totalErrors === 0)
+        && (!verification || verification.checks.every(c => c.pass))
+    return { id, name, scenarios, verification, pass }
+}

--- a/packages/event-store-bench/src/scenarios/stressTypes.ts
+++ b/packages/event-store-bench/src/scenarios/stressTypes.ts
@@ -1,0 +1,13 @@
+import { ScenarioResult } from "../harness/types"
+
+export interface StressTestResult {
+    id: string
+    name: string
+    scenarios: ScenarioResult[]
+    verification?: VerificationResult
+    pass: boolean
+}
+
+export interface VerificationResult {
+    checks: Array<{ name: string; expected: string; actual: string; pass: boolean }>
+}

--- a/packages/event-store-bench/src/scenarios/t1-throughput.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t1-throughput.tests.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t1-throughput"
+import { TierConfig } from "./helpers"
+
+const FAST_TIERS: TierConfig[] = [
+    { name: "1-writer", workers: 1, durationMs: 1_000 },
+    { name: "5-writers", workers: 5, durationMs: 1_000 },
+]
+
+describe("T1 — Throughput Baseline", () => {
+    it("completes with correct structure and no errors", async () => {
+        const result = await run(() => new MemoryEventStore(), FAST_TIERS)
+
+        expect(result.id).toBe("T1")
+        expect(result.scenarios).toHaveLength(2)
+
+        for (const scenario of result.scenarios) {
+            expect(scenario.aggregate.totalErrors).toBe(0)
+            expect(scenario.workers.length).toBeGreaterThan(0)
+            expect(scenario.aggregate.totalOperations).toBeGreaterThan(0)
+        }
+    })
+
+    it("multi-writer tier has non-zero throughput (scaling requires real DB)", async () => {
+        const result = await run(() => new MemoryEventStore(), FAST_TIERS)
+
+        // MemoryEventStore is single-threaded — can't demonstrate scaling.
+        // Just verify both tiers produced meaningful throughput.
+        for (const s of result.scenarios) {
+            expect(s.aggregate.eventsPerSec).toBeGreaterThan(0)
+        }
+    })
+
+    it("includes verification checks", async () => {
+        const result = await run(() => new MemoryEventStore(), FAST_TIERS)
+
+        expect(result.verification).toBeDefined()
+        expect(result.verification!.checks).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ name: "scaling-factor" }),
+                expect.objectContaining({ name: "p99-latency-all-tiers" }),
+                expect.objectContaining({ name: "zero-errors" }),
+            ]),
+        )
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t1-throughput.ts
+++ b/packages/event-store-bench/src/scenarios/t1-throughput.ts
@@ -1,0 +1,81 @@
+import { StressTestResult } from "./stressTypes"
+import { ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+import { conditionalRetryWorker, TierConfig, runTieredScenario } from "./helpers"
+import { t1EventFactory, t1QueryFactory } from "./factories"
+
+const DEFAULT_TIERS: TierConfig[] = [
+    { name: "1-writer", workers: 1, durationMs: 15_000 },
+    { name: "5-writers", workers: 5, durationMs: 15_000 },
+    { name: "10-writers", workers: 10, durationMs: 15_000 },
+    { name: "20-writers", workers: 20, durationMs: 15_000 },
+]
+
+export async function run(
+    factory: EventStoreFactory,
+    tiers: TierConfig[] = DEFAULT_TIERS,
+): Promise<StressTestResult> {
+    async function runTier(tier: TierConfig): Promise<ScenarioResult> {
+        const eventStore = await factory(`t1-${Date.now()}`)
+        const endTime = Date.now() + tier.durationMs
+
+        const workers = await Promise.all(
+            Array.from({ length: tier.workers }, (_, i) =>
+                conditionalRetryWorker(eventStore, t1QueryFactory(i), t1EventFactory, i, endTime),
+            ),
+        )
+
+        const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+        return {
+            scenario: `T1-${tier.name}`,
+            description: `Throughput baseline: ${tier.workers} isolated writers`,
+            durationMs: tier.durationMs,
+            workers,
+            aggregate: aggregateResults(workers, tier.durationMs, totalEvents),
+        }
+    }
+
+    const result = await runTieredScenario(
+        "T1",
+        "Throughput Baseline & Linear Scaling",
+        tiers,
+        runTier,
+    )
+
+    const scenarios = result.scenarios
+    const tier1 = scenarios[0].aggregate.eventsPerSec
+    const tierN = scenarios[scenarios.length - 1].aggregate.eventsPerSec
+    const scalingFactor = tierN / Math.max(tier1, 1)
+
+    const pass = scalingFactor >= 2
+        && scenarios.every(s => s.aggregate.latency.p99 < 25)
+        && scenarios.every(s => s.aggregate.totalErrors === 0)
+
+    return {
+        ...result,
+        pass,
+        verification: {
+            checks: [
+                {
+                    name: "scaling-factor",
+                    expected: ">=2",
+                    actual: scalingFactor.toFixed(2),
+                    pass: scalingFactor >= 2,
+                },
+                {
+                    name: "p99-latency-all-tiers",
+                    expected: "<25ms",
+                    actual: scenarios.map(s => `${s.scenario}=${s.aggregate.latency.p99}ms`).join(", "),
+                    pass: scenarios.every(s => s.aggregate.latency.p99 < 25),
+                },
+                {
+                    name: "zero-errors",
+                    expected: "0",
+                    actual: String(scenarios.reduce((sum, s) => sum + s.aggregate.totalErrors, 0)),
+                    pass: scenarios.every(s => s.aggregate.totalErrors === 0),
+                },
+            ],
+        },
+    }
+}

--- a/packages/event-store-bench/src/scenarios/t10-esb-compat.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t10-esb-compat.tests.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t10-esb-compat"
+import { TierConfig } from "./helpers"
+
+const FAST_TIERS: TierConfig[] = [
+    { name: "1w", workers: 1, durationMs: 1_000 },
+    { name: "2w", workers: 2, durationMs: 1_000 },
+]
+
+describe("T10 — ESB-compat Benchmark", () => {
+    it("write phase completes with zero errors", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { writeOnly: true, writeTiers: FAST_TIERS },
+        )
+
+        expect(result.id).toBe("T10")
+        expect(result.scenarios.length).toBe(2)
+
+        for (const s of result.scenarios) {
+            expect(s.aggregate.totalErrors).toBe(0)
+            expect(s.aggregate.totalOperations).toBeGreaterThan(0)
+        }
+    })
+
+    it("read phase completes with zero errors", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { readOnly: true, readTiers: FAST_TIERS },
+        )
+
+        expect(result.id).toBe("T10")
+
+        for (const s of result.scenarios) {
+            expect(s.aggregate.totalErrors).toBe(0)
+            expect(s.aggregate.totalOperations).toBeGreaterThan(0)
+        }
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t10-esb-compat.ts
+++ b/packages/event-store-bench/src/scenarios/t10-esb-compat.ts
@@ -1,0 +1,206 @@
+import {
+    EventStore,
+    Tags,
+    Query,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+import { TierConfig, runTieredScenario } from "./helpers"
+
+const PAYLOAD = "x".repeat(256)
+const STREAM_ROTATE = 10
+const PREPOPULATE_STREAMS = 500
+const PREPOPULATE_EVENTS_PER_STREAM = 10
+const READ_LIMIT = 10
+
+const WRITE_TIERS: TierConfig[] = [
+    { name: "1w",  workers: 1,  durationMs: 20_000 },
+    { name: "2w",  workers: 2,  durationMs: 20_000 },
+    { name: "4w",  workers: 4,  durationMs: 20_000 },
+    { name: "8w",  workers: 8,  durationMs: 20_000 },
+    { name: "16w", workers: 16, durationMs: 20_000 },
+    { name: "32w", workers: 32, durationMs: 20_000 },
+]
+
+const READ_TIERS: TierConfig[] = [
+    { name: "1r",  workers: 1,  durationMs: 20_000 },
+    { name: "2r",  workers: 2,  durationMs: 20_000 },
+    { name: "4r",  workers: 4,  durationMs: 20_000 },
+    { name: "8r",  workers: 8,  durationMs: 20_000 },
+    { name: "16r", workers: 16, durationMs: 20_000 },
+    { name: "32r", workers: 32, durationMs: 20_000 },
+]
+
+async function unconditionalAppendWorker(
+    eventStore: EventStore,
+    workerId: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    let streamSeq = 0
+
+    while (Date.now() < endTime) {
+        const streamId = `W${workerId}-S${Math.floor(streamSeq / STREAM_ROTATE)}`
+        streamSeq++
+
+        const event = {
+            type: "BenchEvent",
+            tags: Tags.fromObj({ stream: streamId }),
+            data: { payload: PAYLOAD },
+            metadata: {},
+        }
+
+        const opStart = Date.now()
+        try {
+            await eventStore.append({ events: event })
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events++
+        } catch {
+            result.errors++
+        }
+    }
+
+    return result
+}
+
+async function readWorker(
+    eventStore: EventStore,
+    streamCount: number,
+    workerId: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "read", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    let seq = workerId
+
+    while (Date.now() < endTime) {
+        const streamIdx = seq % streamCount
+        seq++
+
+        const query = Query.fromItems([{
+            types: ["BenchEvent"],
+            tags: Tags.fromObj({ stream: `P${streamIdx}` }),
+        }])
+
+        const opStart = Date.now()
+        try {
+            const events = await streamAllEventsToArray(
+                eventStore.read(query, { limit: READ_LIMIT }),
+            )
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += events.length
+        } catch {
+            result.errors++
+        }
+    }
+
+    return result
+}
+
+async function prepopulate(eventStore: EventStore): Promise<void> {
+    const batchSize = 500
+    const total = PREPOPULATE_STREAMS * PREPOPULATE_EVENTS_PER_STREAM
+    for (let offset = 0; offset < total; offset += batchSize) {
+        const size = Math.min(batchSize, total - offset)
+        const events = Array.from({ length: size }, (_, i) => {
+            const globalIdx = offset + i
+            const streamIdx = globalIdx % PREPOPULATE_STREAMS
+            return {
+                type: "BenchEvent",
+                tags: Tags.fromObj({ stream: `P${streamIdx}` }),
+                data: { payload: PAYLOAD },
+                metadata: {},
+            }
+        })
+        await eventStore.append({ events })
+    }
+}
+
+export interface T10Options {
+    writeOnly?: boolean
+    readOnly?: boolean
+    writeTiers?: TierConfig[]
+    readTiers?: TierConfig[]
+}
+
+export async function run(
+    factory: EventStoreFactory,
+    opts?: T10Options,
+): Promise<StressTestResult> {
+    const writePhase = !opts?.readOnly
+    const readPhase = !opts?.writeOnly
+    const writeTiers = opts?.writeTiers ?? WRITE_TIERS
+    const readTiers = opts?.readTiers ?? READ_TIERS
+
+    const allScenarios: ScenarioResult[] = []
+
+    if (writePhase) {
+        const writeResult = await runTieredScenario(
+            "T10-write", "ESB-compat Writes",
+            writeTiers,
+            async (tier) => {
+                const eventStore = await factory(`t10w-${tier.name}-${Date.now()}`)
+                const endTime = Date.now() + tier.durationMs
+
+                const workers = await Promise.all(
+                    Array.from({ length: tier.workers }, (_, i) =>
+                        unconditionalAppendWorker(eventStore, i, endTime),
+                    ),
+                )
+
+                const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+                return {
+                    scenario: `T10-write-${tier.name}`,
+                    description: `${tier.workers} unconditional writers, 1 event/op, 256B payload`,
+                    durationMs: tier.durationMs,
+                    workers,
+                    aggregate: aggregateResults(workers, tier.durationMs, totalEvents),
+                }
+            },
+        )
+        allScenarios.push(...writeResult.scenarios)
+    }
+
+    if (readPhase) {
+        const readStore = await factory(`t10r-${Date.now()}`)
+        await prepopulate(readStore)
+
+        const readResult = await runTieredScenario(
+            "T10-read", "ESB-compat Reads",
+            readTiers,
+            async (tier) => {
+                const endTime = Date.now() + tier.durationMs
+
+                const workers = await Promise.all(
+                    Array.from({ length: tier.workers }, (_, i) =>
+                        readWorker(readStore, PREPOPULATE_STREAMS, i, endTime),
+                    ),
+                )
+
+                const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+                return {
+                    scenario: `T10-read-${tier.name}`,
+                    description: `${tier.workers} readers, limit=${READ_LIMIT}, ${PREPOPULATE_STREAMS} streams`,
+                    durationMs: tier.durationMs,
+                    workers,
+                    aggregate: aggregateResults(workers, tier.durationMs, totalEvents),
+                }
+            },
+        )
+        allScenarios.push(...readResult.scenarios)
+    }
+
+    const pass = allScenarios.every(s => s.aggregate.totalErrors === 0)
+
+    return { id: "T10", name: "ESB-compat Benchmark", scenarios: allScenarios, pass }
+}

--- a/packages/event-store-bench/src/scenarios/t11-meter-upsert.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t11-meter-upsert.tests.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t11-meter-upsert"
+
+describe("T11 — Meter Upsert", () => {
+    it("upserts all meters with correct state transitions", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { totalMeters: 30 },
+        )
+
+        expect(result.id).toBe("T11")
+        expect(result.verification).toBeDefined()
+
+        const aliveCheck = result.verification!.checks.find(c => c.name === "all-meters-alive")
+        expect(aliveCheck?.pass).toBe(true)
+
+        const dupCheck = result.verification!.checks.find(c => c.name === "no-duplicate-creates")
+        expect(dupCheck?.pass).toBe(true)
+
+        expect(result.pass).toBe(true)
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t11-meter-upsert.ts
+++ b/packages/event-store-bench/src/scenarios/t11-meter-upsert.ts
@@ -1,0 +1,220 @@
+import {
+    EventStore,
+    Tags,
+    Query,
+    SequencePosition,
+    AppendCondition,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult, VerificationResult } from "./stressTypes"
+import { ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { computeLatencyStats } from "../harness/stats"
+
+export interface T11Config {
+    totalMeters: number
+}
+
+const DEFAULT_CONFIG: T11Config = { totalMeters: 25_000 }
+
+export async function run(
+    factory: EventStoreFactory,
+    config: T11Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const { totalMeters } = config
+    const existingCount = Math.floor(totalMeters / 3)
+    const neverExistedCount = Math.floor(totalMeters / 3)
+    const deletedCount = totalMeters - existingCount - neverExistedCount
+
+    const eventStore = await factory(`t11-${Date.now()}`)
+
+    // Phase 1: Setup
+    const BATCH = 2_500
+
+    const metersToCreate = existingCount + deletedCount
+    for (let offset = 0; offset < metersToCreate; offset += BATCH) {
+        const size = Math.min(BATCH, metersToCreate - offset)
+        const events = Array.from({ length: size }, (_, i) => ({
+            type: "MeterCreated",
+            tags: Tags.fromObj({ serial: `M${offset + i}` }),
+            data: { serial: offset + i },
+            metadata: {},
+        }))
+        await eventStore.append({ events })
+    }
+
+    for (let offset = 0; offset < deletedCount; offset += BATCH) {
+        const size = Math.min(BATCH, deletedCount - offset)
+        const events = Array.from({ length: size }, (_, i) => {
+            const meterIdx = existingCount + offset + i
+            return {
+                type: "MeterDeleted",
+                tags: Tags.fromObj({ serial: `M${meterIdx}` }),
+                data: { serial: meterIdx },
+                metadata: {},
+            }
+        })
+        await eventStore.append({ events })
+    }
+
+    // Phase 2: Read
+    const readStart = Date.now()
+
+    const meterQuery = Query.fromItems([
+        { types: ["MeterCreated", "MeterDeleted"] },
+    ])
+
+    const allEvents = await streamAllEventsToArray(eventStore.read(meterQuery))
+    const readPosition = allEvents.length > 0
+        ? allEvents[allEvents.length - 1].position
+        : SequencePosition.initial()
+
+    const readElapsed = Date.now() - readStart
+
+    // Phase 3: Decide
+    const decideStart = Date.now()
+
+    const meterState = new Map<string, "alive" | "deleted">()
+    for (const evt of allEvents) {
+        const serial = evt.event.tags.values.find(t => t.startsWith("serial="))
+        if (!serial) continue
+        if (evt.event.type === "MeterCreated") {
+            meterState.set(serial, "alive")
+        } else if (evt.event.type === "MeterDeleted") {
+            meterState.set(serial, "deleted")
+        }
+    }
+
+    const metersToUpsert: number[] = []
+    for (let i = 0; i < totalMeters; i++) {
+        const state = meterState.get(`serial=M${i}`)
+        if (state !== "alive") {
+            metersToUpsert.push(i)
+        }
+    }
+
+    const decideElapsed = Date.now() - decideStart
+
+    // Phase 4: Write
+    const writeStart = Date.now()
+
+    const commands = metersToUpsert.map(meterIdx => {
+        const serial = `M${meterIdx}`
+        const condition: AppendCondition = {
+            failIfEventsMatch: Query.fromItems([{
+                types: ["MeterCreated"],
+                tags: Tags.fromObj({ serial }),
+            }]),
+            after: readPosition,
+        }
+        return {
+            events: {
+                type: "MeterCreated",
+                tags: Tags.fromObj({ serial }),
+                data: { serial: meterIdx },
+                metadata: {},
+            },
+            condition,
+        }
+    })
+
+    await eventStore.append(commands)
+
+    const writeElapsed = Date.now() - writeStart
+    const totalElapsed = readElapsed + decideElapsed + writeElapsed
+
+    const scenario: ScenarioResult = {
+        scenario: "T11-meter-upsert",
+        description: `${totalMeters} meters: ${existingCount} existing, ${neverExistedCount} new, ${deletedCount} deleted -> ${metersToUpsert.length} upserted`,
+        durationMs: totalElapsed,
+        workers: [
+            {
+                workerId: 0,
+                type: "read" as const,
+                operations: 1,
+                events: allEvents.length,
+                errors: 0,
+                conflicts: 0,
+                latencies: [readElapsed],
+            },
+            {
+                workerId: 1,
+                type: "write" as const,
+                operations: 1,
+                events: metersToUpsert.length,
+                errors: 0,
+                conflicts: 0,
+                latencies: [writeElapsed],
+            },
+        ],
+        aggregate: {
+            totalOperations: 2,
+            totalErrors: 0,
+            totalConflicts: 0,
+            opsPerSec: Math.round(2 / (totalElapsed / 1000)),
+            eventsPerSec: Math.round(metersToUpsert.length / (totalElapsed / 1000)),
+            latency: computeLatencyStats([readElapsed, writeElapsed]),
+        },
+    }
+
+    const verification = await verify(eventStore, totalMeters)
+    const pass = verification.checks.every(c => c.pass)
+
+    return { id: "T11", name: "Meter Upsert", scenarios: [scenario], verification, pass }
+}
+
+async function verify(
+    eventStore: EventStore,
+    totalMeters: number,
+): Promise<VerificationResult> {
+    const checks: VerificationResult["checks"] = []
+
+    const query = Query.fromItems([{ types: ["MeterCreated", "MeterDeleted"] }])
+    const allEvents = await streamAllEventsToArray(eventStore.read(query))
+
+    const state = new Map<string, "alive" | "deleted">()
+    for (const evt of allEvents) {
+        const serial = evt.event.tags.values.find(t => t.startsWith("serial="))
+        if (!serial) continue
+        if (evt.event.type === "MeterCreated") state.set(serial, "alive")
+        else if (evt.event.type === "MeterDeleted") state.set(serial, "deleted")
+    }
+
+    const aliveCount = [...state.values()].filter(s => s === "alive").length
+
+    checks.push({
+        name: "all-meters-alive",
+        expected: String(totalMeters),
+        actual: String(aliveCount),
+        pass: aliveCount === totalMeters,
+    })
+
+    const createdCounts = new Map<string, number>()
+    for (const evt of allEvents) {
+        if (evt.event.type !== "MeterCreated") continue
+        const serial = evt.event.tags.values.find(t => t.startsWith("serial="))
+        if (!serial) continue
+        createdCounts.set(serial, (createdCounts.get(serial) ?? 0) + 1)
+    }
+
+    const existingCount = Math.floor(totalMeters / 3)
+    const deletedCount = totalMeters - existingCount - Math.floor(totalMeters / 3)
+    let duplicateErrors = 0
+
+    for (let i = 0; i < totalMeters; i++) {
+        const serial = `serial=M${i}`
+        const count = createdCounts.get(serial) ?? 0
+        const isDeleted = i >= existingCount && i < existingCount + deletedCount
+        const expectedCreates = isDeleted ? 2 : 1
+        if (count !== expectedCreates) duplicateErrors++
+    }
+
+    checks.push({
+        name: "no-duplicate-creates",
+        expected: "0 errors",
+        actual: `${duplicateErrors} errors`,
+        pass: duplicateErrors === 0,
+    })
+
+    return { checks }
+}

--- a/packages/event-store-bench/src/scenarios/t12-batch-throughput.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t12-batch-throughput.tests.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t12-batch-throughput"
+
+describe("T12 — Batch Throughput Sweep", () => {
+    it("unconditional: all batch tiers complete with zero errors", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { workerCount: 2, batchSizes: [1, 10], durationPerTierMs: 1_000, conditional: false },
+        )
+
+        expect(result.id).toBe("T12")
+        expect(result.scenarios).toHaveLength(2)
+        for (const s of result.scenarios) {
+            expect(s.aggregate.totalErrors).toBe(0)
+            expect(s.aggregate.totalOperations).toBeGreaterThan(0)
+        }
+    })
+
+    it("conditional: all batch tiers complete with zero errors", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { workerCount: 2, batchSizes: [1, 10], durationPerTierMs: 1_000, conditional: true },
+        )
+
+        expect(result.scenarios).toHaveLength(2)
+        for (const s of result.scenarios) {
+            expect(s.aggregate.totalErrors).toBe(0)
+            expect(s.aggregate.totalOperations).toBeGreaterThan(0)
+        }
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t12-batch-throughput.ts
+++ b/packages/event-store-bench/src/scenarios/t12-batch-throughput.ts
@@ -1,0 +1,132 @@
+import {
+    EventStore,
+    AppendConditionError,
+    Tags,
+    Query,
+    SequencePosition,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+
+// ─── T12: Batch Insert Throughput Sweep ────────────────────────────
+//
+// 10 workers on isolated scopes, varying batch size (events per append).
+// Tests both unconditional and conditional modes.
+// Replicates the benchmark from stress-results-2026-04-10.
+
+export interface T12Config {
+    workerCount: number
+    batchSizes: number[]
+    durationPerTierMs: number
+    conditional: boolean
+}
+
+const DEFAULT_CONFIG: T12Config = {
+    workerCount: 10,
+    batchSizes: [1, 10, 50, 100, 500],
+    durationPerTierMs: 15_000,
+    conditional: false,
+}
+
+async function batchWorker(
+    eventStore: EventStore,
+    workerId: number,
+    batchSize: number,
+    conditional: boolean,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    const scopeTag = `W${workerId}`
+    let lastPosition: SequencePosition | undefined
+    let iteration = 0
+
+    while (Date.now() < endTime) {
+        const events = Array.from({ length: batchSize }, (_, i) => ({
+            type: "BatchEvent",
+            tags: Tags.fromObj({ scope: scopeTag }),
+            data: { seq: iteration * batchSize + i },
+            metadata: {},
+        }))
+
+        const opStart = Date.now()
+        try {
+            if (conditional) {
+                const scopeQuery = Query.fromItems([{ types: ["BatchEvent"], tags: Tags.fromObj({ scope: scopeTag }) }])
+
+                if (lastPosition === undefined) {
+                    const [latest] = await streamAllEventsToArray(
+                        eventStore.read(scopeQuery, { backwards: true, limit: 1 }),
+                    )
+                    lastPosition = latest?.position ?? SequencePosition.initial()
+                }
+
+                lastPosition = await eventStore.append({
+                    events,
+                    condition: { failIfEventsMatch: scopeQuery, after: lastPosition },
+                })
+            } else {
+                await eventStore.append({ events })
+            }
+
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += batchSize
+        } catch (err) {
+            if (err instanceof AppendConditionError) {
+                result.conflicts++
+                lastPosition = undefined
+            } else {
+                result.errors++
+            }
+        }
+
+        iteration++
+    }
+
+    return result
+}
+
+export async function run(
+    factory: EventStoreFactory,
+    config: T12Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const mode = config.conditional ? "conditional" : "unconditional"
+    const allScenarios: ScenarioResult[] = []
+
+    for (const batchSize of config.batchSizes) {
+        const eventStore = await factory(`t12-${mode}-b${batchSize}-${Date.now()}`)
+        const endTime = Date.now() + config.durationPerTierMs
+
+        const workers = await Promise.all(
+            Array.from({ length: config.workerCount }, (_, i) =>
+                batchWorker(eventStore, i, batchSize, config.conditional, endTime),
+            ),
+        )
+
+        const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+        const aggregate = aggregateResults(workers, config.durationPerTierMs, totalEvents)
+
+        allScenarios.push({
+            scenario: `T12-batch-${batchSize}-${mode}`,
+            description: `${config.workerCount} workers, batch=${batchSize}, ${mode}`,
+            durationMs: config.durationPerTierMs,
+            workers,
+            aggregate,
+        })
+    }
+
+    const pass = allScenarios.every(s => s.aggregate.totalErrors === 0)
+
+    return {
+        id: "T12",
+        name: `Batch Throughput Sweep (${mode})`,
+        scenarios: allScenarios,
+        pass,
+    }
+}

--- a/packages/event-store-bench/src/scenarios/t13-degradation.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t13-degradation.tests.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t13-degradation"
+
+describe("T13 — Degradation Under Load", () => {
+    it("completes multiple phases with zero errors", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { workerCount: 2, batchSize: 10, phases: 2, durationPerPhaseMs: 1_000, conditional: true },
+        )
+
+        expect(result.id).toBe("T13")
+        expect(result.scenarios).toHaveLength(2)
+        for (const s of result.scenarios) {
+            expect(s.aggregate.totalErrors).toBe(0)
+            expect(s.aggregate.totalOperations).toBeGreaterThan(0)
+        }
+        expect(result.pass).toBe(true)
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t13-degradation.ts
+++ b/packages/event-store-bench/src/scenarios/t13-degradation.ts
@@ -1,0 +1,147 @@
+import {
+    EventStore,
+    AppendConditionError,
+    Tags,
+    Query,
+    SequencePosition,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+
+// ─── T13: Degradation Under Load ──────────────────────────────────
+//
+// Measures throughput over multiple phases as the table grows.
+// 10 workers, batch-500, conditional appends on isolated scopes.
+// Replicates the "Batch-500 Degradation to 5M" benchmark.
+
+export interface T13Config {
+    workerCount: number
+    batchSize: number
+    phases: number
+    durationPerPhaseMs: number
+    conditional: boolean
+}
+
+const DEFAULT_CONFIG: T13Config = {
+    workerCount: 10,
+    batchSize: 500,
+    phases: 4,
+    durationPerPhaseMs: 30_000,
+    conditional: true,
+}
+
+async function phaseWorker(
+    eventStore: EventStore,
+    workerId: number,
+    batchSize: number,
+    conditional: boolean,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    const scopeTag = `W${workerId}`
+    let lastPosition: SequencePosition | undefined
+    let iteration = 0
+
+    while (Date.now() < endTime) {
+        const events = Array.from({ length: batchSize }, (_, i) => ({
+            type: "DegradationEvent",
+            tags: Tags.fromObj({ scope: scopeTag }),
+            data: { seq: iteration * batchSize + i },
+            metadata: {},
+        }))
+
+        const opStart = Date.now()
+        try {
+            if (conditional) {
+                const scopeQuery = Query.fromItems([{ types: ["DegradationEvent"], tags: Tags.fromObj({ scope: scopeTag }) }])
+
+                if (lastPosition === undefined) {
+                    const [latest] = await streamAllEventsToArray(
+                        eventStore.read(scopeQuery, { backwards: true, limit: 1 }),
+                    )
+                    lastPosition = latest?.position ?? SequencePosition.initial()
+                }
+
+                lastPosition = await eventStore.append({
+                    events,
+                    condition: { failIfEventsMatch: scopeQuery, after: lastPosition },
+                })
+            } else {
+                await eventStore.append({ events })
+            }
+
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += batchSize
+        } catch (err) {
+            if (err instanceof AppendConditionError) {
+                result.conflicts++
+                lastPosition = undefined
+            } else {
+                result.errors++
+            }
+        }
+
+        iteration++
+    }
+
+    return result
+}
+
+export async function run(
+    factory: EventStoreFactory,
+    config: T13Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const mode = config.conditional ? "conditional" : "unconditional"
+    // Single store across all phases — table grows
+    const eventStore = await factory(`t13-degrad-${Date.now()}`)
+
+    const allScenarios: ScenarioResult[] = []
+    let cumulativeEvents = 0
+
+    for (let phase = 1; phase <= config.phases; phase++) {
+        const endTime = Date.now() + config.durationPerPhaseMs
+
+        const workers = await Promise.all(
+            Array.from({ length: config.workerCount }, (_, i) =>
+                phaseWorker(eventStore, i, config.batchSize, config.conditional, endTime),
+            ),
+        )
+
+        const phaseEvents = workers.reduce((sum, w) => sum + w.events, 0)
+        cumulativeEvents += phaseEvents
+        const aggregate = aggregateResults(workers, config.durationPerPhaseMs, phaseEvents)
+
+        allScenarios.push({
+            scenario: `T13-phase-${phase}`,
+            description: `Phase ${phase}: ~${(cumulativeEvents / 1000).toFixed(0)}K rows, batch=${config.batchSize}, ${mode}`,
+            durationMs: config.durationPerPhaseMs,
+            workers,
+            aggregate,
+        })
+    }
+
+    const pass = allScenarios.every(s => s.aggregate.totalErrors === 0)
+
+    // Build verification: show degradation curve
+    const checks = allScenarios.map((s, i) => ({
+        name: `phase-${i + 1}-throughput`,
+        expected: "> 0",
+        actual: `${s.aggregate.eventsPerSec} ev/sec`,
+        pass: s.aggregate.totalErrors === 0,
+    }))
+
+    return {
+        id: "T13",
+        name: `Degradation Under Load (${mode})`,
+        scenarios: allScenarios,
+        verification: { checks },
+        pass,
+    }
+}

--- a/packages/event-store-bench/src/scenarios/t14-copy-threshold.ts
+++ b/packages/event-store-bench/src/scenarios/t14-copy-threshold.ts
@@ -1,0 +1,105 @@
+import {
+    EventStore,
+    Tags,
+} from "@dcb-es/event-store"
+import { StressTestResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult, ThresholdFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+
+// ─── T14: Copy Threshold Sweep ─────────────────────────────────────
+//
+// Holds batch size constant, varies the copyThreshold setting on
+// PostgresEventStore to find the crossover point where COPY FROM
+// beats the stored procedure path.
+//
+// Requires a factory that accepts copyThreshold as a parameter.
+
+export interface T14Config {
+    workerCount: number
+    batchSize: number
+    thresholds: number[]
+    durationPerTierMs: number
+}
+
+const DEFAULT_CONFIG: T14Config = {
+    workerCount: 10,
+    batchSize: 500,
+    thresholds: [10, 100, 250, 500, 1000, 2500],
+    durationPerTierMs: 15_000,
+}
+
+async function worker(
+    eventStore: EventStore,
+    workerId: number,
+    batchSize: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    const scopeTag = `W${workerId}`
+    let iteration = 0
+
+    while (Date.now() < endTime) {
+        const events = Array.from({ length: batchSize }, (_, i) => ({
+            type: "ThresholdEvent",
+            tags: Tags.fromObj({ scope: scopeTag }),
+            data: { seq: iteration * batchSize + i },
+            metadata: {},
+        }))
+
+        const opStart = Date.now()
+        try {
+            await eventStore.append({ events })
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += batchSize
+        } catch {
+            result.errors++
+        }
+
+        iteration++
+    }
+
+    return result
+}
+
+export async function run(
+    factory: ThresholdFactory,
+    config: T14Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const allScenarios: ScenarioResult[] = []
+
+    for (const threshold of config.thresholds) {
+        const eventStore = await factory(`t14-thresh${threshold}-${Date.now()}`, threshold)
+        const endTime = Date.now() + config.durationPerTierMs
+
+        const workers = await Promise.all(
+            Array.from({ length: config.workerCount }, (_, i) =>
+                worker(eventStore, i, config.batchSize, endTime),
+            ),
+        )
+
+        const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+        const aggregate = aggregateResults(workers, config.durationPerTierMs, totalEvents)
+
+        const route = config.batchSize <= threshold ? "function" : "COPY"
+        allScenarios.push({
+            scenario: `T14-threshold-${threshold}`,
+            description: `batch=${config.batchSize}, copyThreshold=${threshold}, route=${route}, ${config.workerCount} workers`,
+            durationMs: config.durationPerTierMs,
+            workers,
+            aggregate,
+        })
+    }
+
+    const pass = allScenarios.every(s => s.aggregate.totalErrors === 0)
+
+    return {
+        id: "T14",
+        name: `Copy Threshold Sweep (batch=${config.batchSize})`,
+        scenarios: allScenarios,
+        pass,
+    }
+}

--- a/packages/event-store-bench/src/scenarios/t15-copy-crossover.ts
+++ b/packages/event-store-bench/src/scenarios/t15-copy-crossover.ts
@@ -1,0 +1,103 @@
+import {
+    EventStore,
+    Tags,
+} from "@dcb-es/event-store"
+import { StressTestResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult, ThresholdFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+
+// ─── T15: Copy vs Function Crossover ───────────────────────────────
+//
+// For each batch size, runs once with function path (high threshold)
+// and once with COPY path (threshold=1), so we can compare directly.
+
+export interface T15Config {
+    workerCount: number
+    batchSizes: number[]
+    durationPerTierMs: number
+}
+
+const DEFAULT_CONFIG: T15Config = {
+    workerCount: 10,
+    batchSizes: [100, 500, 1000, 2500, 5000],
+    durationPerTierMs: 10_000,
+}
+
+async function worker(
+    eventStore: EventStore,
+    workerId: number,
+    batchSize: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    const scopeTag = `W${workerId}`
+    let iteration = 0
+
+    while (Date.now() < endTime) {
+        const events = Array.from({ length: batchSize }, (_, i) => ({
+            type: "CrossoverEvent",
+            tags: Tags.fromObj({ scope: scopeTag }),
+            data: { seq: iteration * batchSize + i },
+            metadata: {},
+        }))
+
+        const opStart = Date.now()
+        try {
+            await eventStore.append({ events })
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += batchSize
+        } catch {
+            result.errors++
+        }
+
+        iteration++
+    }
+
+    return result
+}
+
+export async function run(
+    factory: ThresholdFactory,
+    config: T15Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const allScenarios: ScenarioResult[] = []
+
+    for (const batchSize of config.batchSizes) {
+        for (const route of ["function", "COPY"] as const) {
+            // threshold > batchSize → function path; threshold = 1 → COPY path
+            const copyThreshold = route === "function" ? batchSize + 1 : 1
+            const eventStore = await factory(`t15-b${batchSize}-${route}-${Date.now()}`, copyThreshold)
+            const endTime = Date.now() + config.durationPerTierMs
+
+            const workers = await Promise.all(
+                Array.from({ length: config.workerCount }, (_, i) =>
+                    worker(eventStore, i, batchSize, endTime),
+                ),
+            )
+
+            const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+            const aggregate = aggregateResults(workers, config.durationPerTierMs, totalEvents)
+
+            allScenarios.push({
+                scenario: `batch-${batchSize}-${route}`,
+                description: `batch=${batchSize}, route=${route}, ${config.workerCount} workers`,
+                durationMs: config.durationPerTierMs,
+                workers,
+                aggregate,
+            })
+        }
+    }
+
+    const pass = allScenarios.every(s => s.aggregate.totalErrors === 0)
+
+    return {
+        id: "T15",
+        name: "Copy vs Function Crossover",
+        scenarios: allScenarios,
+        pass,
+    }
+}

--- a/packages/event-store-bench/src/scenarios/t16-batch-commands.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t16-batch-commands.tests.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t16-batch-commands"
+
+describe("T16 — Batch Commands Throughput", () => {
+    it("completes all tiers with zero errors", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { workerCount: 2, commandsPerAppend: [1, 5], durationPerTierMs: 1_000 },
+        )
+
+        expect(result.id).toBe("T16")
+        expect(result.scenarios).toHaveLength(2)
+        for (const s of result.scenarios) {
+            expect(s.aggregate.totalErrors).toBe(0)
+            expect(s.aggregate.totalOperations).toBeGreaterThan(0)
+        }
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t16-batch-commands.ts
+++ b/packages/event-store-bench/src/scenarios/t16-batch-commands.ts
@@ -1,0 +1,137 @@
+import {
+    EventStore,
+    AppendCommand,
+    AppendConditionError,
+    Tags,
+    Query,
+    SequencePosition,
+} from "@dcb-es/event-store"
+import { StressTestResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+
+// ─── T16: Batch Commands Throughput ────────────────────────────────
+//
+// Each append() call submits N AppendCommands — one event + one
+// condition per command. This is the real-world pattern for bulk
+// imports with per-entity uniqueness constraints.
+//
+// append([
+//   { events: [e1], condition: c1 },
+//   { events: [e2], condition: c2 },
+//   ...
+// ])
+//
+// Routes through appendBatch (COPY + temp table condition checking).
+
+export interface T16Config {
+    workerCount: number
+    commandsPerAppend: number[]
+    durationPerTierMs: number
+}
+
+const DEFAULT_CONFIG: T16Config = {
+    workerCount: 10,
+    commandsPerAppend: [1, 10, 50, 100, 500],
+    durationPerTierMs: 15_000,
+}
+
+async function batchCommandWorker(
+    eventStore: EventStore,
+    workerId: number,
+    commandsPerAppend: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    let seq = 0
+
+    while (Date.now() < endTime) {
+        const commands: AppendCommand[] = Array.from({ length: commandsPerAppend }, (_, i) => {
+            const entityId = `W${workerId}-E${seq++}`
+            return {
+                events: [{
+                    type: "EntityCreated",
+                    tags: Tags.fromObj({ entity: entityId }),
+                    data: { workerId, seq: seq - 1 },
+                    metadata: {},
+                }],
+                condition: {
+                    failIfEventsMatch: Query.fromItems([{
+                        types: ["EntityCreated"],
+                        tags: Tags.fromObj({ entity: entityId }),
+                    }]),
+                    after: SequencePosition.initial(),
+                },
+            }
+        })
+
+        const opStart = Date.now()
+        try {
+            await eventStore.append(commands)
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += commandsPerAppend
+        } catch (err) {
+            if (err instanceof AppendConditionError) {
+                result.conflicts++
+                if (result.conflicts <= 3) {
+                    const idx = err.commandIndex ?? -1
+                    const cmd = idx >= 0 ? commands[idx] : undefined
+                    const evts = cmd ? (Array.isArray(cmd.events) ? cmd.events : [cmd.events]) : []
+                    const tag = evts[0]?.tags?.values?.[0] ?? "?"
+                    console.error(`  [W${workerId}] CONFLICT cmdIdx=${idx} tag=${tag}`)
+                }
+            } else {
+                result.errors++
+                if (result.errors <= 3) {
+                    console.error(`  [W${workerId}] ERROR: ${(err as Error).message?.slice(0, 200)}`)
+                }
+            }
+        }
+    }
+
+    return result
+}
+
+export async function run(
+    factory: EventStoreFactory,
+    config: T16Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const allScenarios: ScenarioResult[] = []
+
+    for (const cmdsPerAppend of config.commandsPerAppend) {
+        // Fresh store per tier to avoid entity ID collisions from prior tiers
+        const eventStore = await factory(`t16-${cmdsPerAppend}cmd-${Date.now()}`)
+        const endTime = Date.now() + config.durationPerTierMs
+
+        const workers = await Promise.all(
+            Array.from({ length: config.workerCount }, (_, i) =>
+                batchCommandWorker(eventStore, i, cmdsPerAppend, endTime),
+            ),
+        )
+
+        const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+        const aggregate = aggregateResults(workers, config.durationPerTierMs, totalEvents)
+
+        allScenarios.push({
+            scenario: `T16-${cmdsPerAppend}cmd`,
+            description: `${config.workerCount} workers, ${cmdsPerAppend} commands/append, each 1 event + 1 condition`,
+            durationMs: config.durationPerTierMs,
+            workers,
+            aggregate,
+        })
+    }
+
+    const pass = allScenarios.every(s => s.aggregate.totalErrors === 0)
+
+    return {
+        id: "T16",
+        name: "Batch Commands Throughput (1 event + 1 condition per command)",
+        scenarios: allScenarios,
+        pass,
+    }
+}

--- a/packages/event-store-bench/src/scenarios/t2-bulk-import.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t2-bulk-import.tests.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t2-bulk-import"
+
+describe("T2 — Bulk Import with DCB Conditions", () => {
+    it("imports meters with correct event counts and no duplicates", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { meterCount: 50, metersPerChunk: 25 },
+        )
+
+        expect(result.id).toBe("T2")
+        expect(result.scenarios).toHaveLength(1)
+
+        const countCheck = result.verification!.checks.find(c => c.name === "total-event-count")
+        expect(countCheck?.pass).toBe(true)
+        expect(countCheck?.expected).toBe(String(50 * 11))
+
+        const dupCheck = result.verification!.checks.find(c => c.name === "no-duplicate-creates")
+        expect(dupCheck?.pass).toBe(true)
+
+        expect(result.scenarios[0].aggregate.totalErrors).toBe(0)
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t2-bulk-import.ts
+++ b/packages/event-store-bench/src/scenarios/t2-bulk-import.ts
@@ -1,0 +1,128 @@
+import {
+    EventStore,
+    Query,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult, VerificationResult } from "./stressTypes"
+import { ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { computeLatencyStats } from "../harness/stats"
+import { buildMeterCommands, EVENTS_PER_METER } from "./factories"
+
+export interface T2Config {
+    meterCount: number
+    metersPerChunk: number
+}
+
+const DEFAULT_CONFIG: T2Config = { meterCount: 50_000, metersPerChunk: 1000 }
+
+export async function run(
+    factory: EventStoreFactory,
+    config: T2Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const eventStore = await factory(`t2-${Date.now()}`)
+    const totalEvents = config.meterCount * EVENTS_PER_METER
+
+    const prepStart = Date.now()
+    const commands = buildMeterCommands(0, config.meterCount)
+    const prepElapsed = Date.now() - prepStart
+
+    const importStart = Date.now()
+    await eventStore.append(commands)
+    const importElapsed = Date.now() - importStart
+
+    const overallElapsed = prepElapsed + importElapsed
+    const importRate = Math.round(totalEvents / (importElapsed / 1000))
+    const overallRate = Math.round(totalEvents / (overallElapsed / 1000))
+
+    const scenario: ScenarioResult = {
+        scenario: "T2-bulk-import",
+        description: `${config.meterCount} meters x ${EVENTS_PER_METER} events = ${totalEvents} total, single append(commands[])`,
+        durationMs: overallElapsed,
+        workers: [{
+            workerId: 0,
+            type: "import",
+            operations: 1,
+            events: totalEvents,
+            errors: 0,
+            conflicts: 0,
+            latencies: [importElapsed],
+        }],
+        aggregate: {
+            totalOperations: 1,
+            totalErrors: 0,
+            totalConflicts: 0,
+            opsPerSec: 1,
+            eventsPerSec: overallRate,
+            latency: computeLatencyStats([importElapsed]),
+        },
+    }
+
+    const verification = await verify(eventStore, config, totalEvents, overallElapsed)
+    const pass = verification.checks.every(c => c.pass)
+
+    return { id: "T2", name: "Bulk Import with DCB Conditions", scenarios: [scenario], verification, pass }
+}
+
+async function verify(
+    eventStore: EventStore,
+    config: T2Config,
+    expectedEvents: number,
+    elapsedMs: number,
+): Promise<VerificationResult> {
+    const checks: VerificationResult["checks"] = []
+
+    const all = await streamAllEventsToArray(eventStore.read(Query.all()))
+    checks.push({
+        name: "total-event-count",
+        expected: String(expectedEvents),
+        actual: String(all.length),
+        pass: all.length === expectedEvents,
+    })
+
+    const meterCounts = new Map<string, number>()
+    for (const se of all) {
+        const meterId = (se.event.data as Record<string, unknown>).meterId as string
+        meterCounts.set(meterId, (meterCounts.get(meterId) ?? 0) + 1)
+    }
+    const wrongCount = [...meterCounts.values()].filter(c => c !== EVENTS_PER_METER).length
+    checks.push({
+        name: "events-per-meter",
+        expected: `all ${config.meterCount} meters have ${EVENTS_PER_METER} events`,
+        actual: wrongCount === 0 ? "all correct" : `${wrongCount} meters with wrong count`,
+        pass: wrongCount === 0,
+    })
+
+    const createEvents = all.filter(se => se.event.type === "MeterCreated")
+    const createMeterIds = createEvents.map(se => (se.event.data as Record<string, unknown>).meterId)
+    const uniqueCreateIds = new Set(createMeterIds)
+    checks.push({
+        name: "no-duplicate-creates",
+        expected: String(config.meterCount),
+        actual: `${uniqueCreateIds.size} unique, ${createMeterIds.length} total`,
+        pass: uniqueCreateIds.size === createMeterIds.length && createMeterIds.length === config.meterCount,
+    })
+
+    const serialEvents = all.filter(se => se.event.type === "SerialNumberSet")
+    const serials = serialEvents.map(se => {
+        const tags = se.event.tags.values
+        return tags.find(t => t.startsWith("serialNumber="))
+    })
+    const uniqueSerials = new Set(serials)
+    checks.push({
+        name: "no-duplicate-serials",
+        expected: String(config.meterCount),
+        actual: `${uniqueSerials.size} unique, ${serials.length} total`,
+        pass: uniqueSerials.size === serials.length && serials.length === config.meterCount,
+    })
+
+    const evPerSec = Math.round(expectedEvents / (elapsedMs / 1000))
+    checks.push({
+        name: "throughput",
+        expected: ">= 10000 ev/sec",
+        actual: `${evPerSec} ev/sec`,
+        pass: evPerSec >= 10_000,
+    })
+
+    return { checks }
+}

--- a/packages/event-store-bench/src/scenarios/t3-contention.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t3-contention.tests.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore, streamAllEventsToArray } from "@dcb-es/event-store"
+import { run } from "./t3-contention"
+import { t3QueryFactory } from "./factories"
+
+describe("T3 — Contention Gauntlet", () => {
+    it("verifies correctness under contention with MemoryEventStore", async () => {
+        let store: MemoryEventStore | undefined
+        const factory = async () => { store = new MemoryEventStore(); return store }
+        const result = await run(factory, { workerCount: 3, durationMs: 2_000 })
+
+        expect(result.verification).toBeDefined()
+
+        const countCheck = result.verification!.checks.find(c => c.name === "event-count-matches-appends")
+        expect(countCheck).toBeDefined()
+        expect(countCheck!.pass).toBe(true)
+
+        for (const scenario of result.scenarios) {
+            expect(scenario.aggregate.totalErrors).toBe(0)
+        }
+
+        const totalOps = result.scenarios[0].workers.reduce((s, w) => s + w.operations, 0)
+        expect(totalOps).toBeGreaterThan(0)
+
+        const events = await streamAllEventsToArray(store!.read(t3QueryFactory(0)))
+        expect(events.length).toBe(totalOps)
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t3-contention.ts
+++ b/packages/event-store-bench/src/scenarios/t3-contention.ts
@@ -1,0 +1,60 @@
+import { EventStore, streamAllEventsToArray } from "@dcb-es/event-store"
+import { StressTestResult, VerificationResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+import { conditionalRetryWorker, verifyAllWorkersProgressed } from "./helpers"
+import { t3EventFactory, t3QueryFactory } from "./factories"
+
+export interface T3Config {
+    workerCount: number
+    durationMs: number
+}
+
+const DEFAULT_CONFIG: T3Config = { workerCount: 20, durationMs: 30_000 }
+
+export async function run(factory: EventStoreFactory, config: T3Config = DEFAULT_CONFIG): Promise<StressTestResult> {
+    const eventStore = await factory(`t3-${Date.now()}`)
+    const endTime = Date.now() + config.durationMs
+    const sharedQuery = t3QueryFactory(0)
+
+    const workers = await Promise.all(
+        Array.from({ length: config.workerCount }, (_, i) =>
+            conditionalRetryWorker(eventStore, sharedQuery, t3EventFactory, i, endTime),
+        ),
+    )
+
+    const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+    const scenario: ScenarioResult = {
+        scenario: "T3-contention",
+        description: `${config.workerCount} writers on single contested scope`,
+        durationMs: config.durationMs,
+        workers,
+        aggregate: aggregateResults(workers, config.durationMs, totalEvents),
+    }
+
+    const verification = await verify(eventStore, workers)
+    const pass = scenario.aggregate.totalErrors === 0
+        && verification.checks.every(c => c.pass)
+
+    return { id: "T3", name: "Contention Gauntlet", scenarios: [scenario], verification, pass }
+}
+
+async function verify(eventStore: EventStore, workers: WorkerResult[]): Promise<VerificationResult> {
+    const checks: VerificationResult["checks"] = []
+
+    const query = t3QueryFactory(0)
+    const events = await streamAllEventsToArray(eventStore.read(query))
+    const totalSuccessful = workers.reduce((sum, w) => sum + w.operations, 0)
+
+    checks.push({
+        name: "event-count-matches-appends",
+        expected: String(totalSuccessful),
+        actual: String(events.length),
+        pass: events.length === totalSuccessful,
+    })
+
+    checks.push(verifyAllWorkersProgressed(workers))
+
+    return { checks }
+}

--- a/packages/event-store-bench/src/scenarios/t4-mixed-workload.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t4-mixed-workload.tests.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t4-mixed-workload"
+
+describe("T4 — Mixed Workload", () => {
+    it("completes import + small writes without errors", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            {
+                importTotalEvents: 100,
+                importBatchSize: 25,
+                importConcurrency: 2,
+                smallWriterCount: 3,
+                smallWriteRatePerSec: 50,
+                durationMs: 3_000,
+            },
+        )
+
+        expect(result.id).toBe("T4")
+        expect(result.scenarios).toHaveLength(3)
+        expect(result.scenarios.map(s => s.scenario)).toEqual([
+            "import",
+            "small-writers-during",
+            "small-writers-after",
+        ])
+
+        const importScenario = result.scenarios[0]
+        expect(importScenario.aggregate.totalErrors).toBe(0)
+        expect(importScenario.workers[0].events).toBe(100)
+
+        const duringScenario = result.scenarios[1]
+        const afterScenario = result.scenarios[2]
+        expect(duringScenario.aggregate.totalErrors).toBe(0)
+        expect(afterScenario.aggregate.totalErrors).toBe(0)
+
+        expect(result.verification).toBeDefined()
+        expect(result.verification!.checks.find(c => c.name === "import-completed")!.pass).toBe(true)
+        expect(result.verification!.checks.find(c => c.name === "small-writer-zero-errors")!.pass).toBe(true)
+
+        expect(result.pass).toBe(true)
+    }, 15_000)
+})

--- a/packages/event-store-bench/src/scenarios/t4-mixed-workload.ts
+++ b/packages/event-store-bench/src/scenarios/t4-mixed-workload.ts
@@ -1,0 +1,220 @@
+import {
+    EventStore,
+    AppendConditionError,
+    SequencePosition,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults, computeLatencyStats } from "../harness/stats"
+import { t4ImportBatchFactory, t4SmallWriteEventFactory, t4SmallWriteQueryFactory } from "./factories"
+
+export interface T4Config {
+    importTotalEvents: number
+    importBatchSize: number
+    importConcurrency: number
+    smallWriterCount: number
+    smallWriteRatePerSec: number
+    durationMs: number
+}
+
+const DEFAULT_CONFIG: T4Config = {
+    importTotalEvents: 50_000,
+    importBatchSize: 1_000,
+    importConcurrency: 2,
+    smallWriterCount: 50,
+    smallWriteRatePerSec: 10,
+    durationMs: 90_000,
+}
+
+async function importWriter(
+    eventStore: EventStore,
+    config: T4Config,
+    importDoneResolve: () => void,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId: -1, type: "import", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    const totalBatches = Math.ceil(config.importTotalEvents / config.importBatchSize)
+    const concurrency = config.importConcurrency ?? 2
+
+    let nextBatch = 0
+    const worker = async () => {
+        while (true) {
+            const i = nextBatch++
+            if (i >= totalBatches) break
+            const batch = t4ImportBatchFactory(0, i, config.importBatchSize)
+            const opStart = Date.now()
+            try {
+                await eventStore.append({ events: batch })
+                result.latencies.push(Date.now() - opStart)
+                result.operations++
+                result.events += batch.length
+            } catch {
+                result.errors++
+            }
+        }
+    }
+
+    await Promise.all(Array.from({ length: concurrency }, () => worker()))
+
+    importDoneResolve()
+    return result
+}
+
+async function smallWriter(
+    eventStore: EventStore,
+    workerId: number,
+    ratePerSec: number,
+    endTime: number,
+    importDonePromise: Promise<void>,
+): Promise<{ worker: WorkerResult; duringLatencies: number[]; afterLatencies: number[] }> {
+    const worker: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+    const duringLatencies: number[] = []
+    const afterLatencies: number[] = []
+    let importDone = false
+
+    importDonePromise.then(() => { importDone = true })
+
+    const query = t4SmallWriteQueryFactory(workerId)
+    const intervalMs = 1000 / ratePerSec
+    let lastPosition: SequencePosition | undefined
+
+    while (Date.now() < endTime) {
+        try {
+            if (lastPosition === undefined) {
+                const [latest] = await streamAllEventsToArray(
+                    eventStore.read(query, { backwards: true, limit: 1 }),
+                )
+                lastPosition = latest?.position ?? SequencePosition.initial()
+            }
+
+            const condition = { failIfEventsMatch: query, after: lastPosition }
+
+            const events = t4SmallWriteEventFactory(workerId)
+            const opStart = Date.now()
+            lastPosition = await eventStore.append({ events, condition })
+            const latency = Date.now() - opStart
+
+            worker.latencies.push(latency)
+            worker.operations++
+            worker.events += events.length
+
+            if (importDone) {
+                afterLatencies.push(latency)
+            } else {
+                duringLatencies.push(latency)
+            }
+        } catch (err) {
+            if (err instanceof AppendConditionError) {
+                worker.conflicts++
+                lastPosition = undefined
+            } else {
+                worker.errors++
+            }
+        }
+
+        await new Promise(resolve => setTimeout(resolve, intervalMs))
+    }
+
+    return { worker, duringLatencies, afterLatencies }
+}
+
+export async function run(factory: EventStoreFactory, config: T4Config = DEFAULT_CONFIG): Promise<StressTestResult> {
+    const eventStore = await factory("t4-mixed-workload")
+    const endTime = Date.now() + config.durationMs
+
+    let importDoneResolve!: () => void
+    const importDonePromise = new Promise<void>(r => { importDoneResolve = r })
+
+    const startTime = Date.now()
+    const importPromise = importWriter(eventStore, config, importDoneResolve)
+    const smallWriterPromises = Array.from({ length: config.smallWriterCount }, (_, i) =>
+        smallWriter(eventStore, i, config.smallWriteRatePerSec, endTime, importDonePromise),
+    )
+
+    const [importResult, ...smallResults] = await Promise.all([importPromise, ...smallWriterPromises])
+    const actualDurationMs = Date.now() - startTime
+
+    const allDuringLatencies = smallResults.flatMap(r => r.duringLatencies)
+    const allAfterLatencies = smallResults.flatMap(r => r.afterLatencies)
+    const allSmallWorkers = smallResults.map(r => r.worker)
+
+    const duringStats = computeLatencyStats(allDuringLatencies)
+    const afterStats = computeLatencyStats(allAfterLatencies)
+
+    const importScenario: ScenarioResult = {
+        scenario: "import",
+        description: `Bulk import of ${config.importTotalEvents} events in batches of ${config.importBatchSize}`,
+        durationMs: actualDurationMs,
+        workers: [importResult],
+        aggregate: aggregateResults([importResult], actualDurationMs, importResult.events),
+    }
+
+    const duringScenario: ScenarioResult = {
+        scenario: "small-writers-during",
+        description: `${config.smallWriterCount} writers at ${config.smallWriteRatePerSec}/sec during import`,
+        durationMs: actualDurationMs,
+        workers: allSmallWorkers,
+        aggregate: {
+            ...aggregateResults(allSmallWorkers, actualDurationMs, allSmallWorkers.reduce((s, w) => s + w.events, 0)),
+            latency: duringStats,
+        },
+    }
+
+    const afterScenario: ScenarioResult = {
+        scenario: "small-writers-after",
+        description: `${config.smallWriterCount} writers at ${config.smallWriteRatePerSec}/sec after import`,
+        durationMs: actualDurationMs,
+        workers: allSmallWorkers,
+        aggregate: {
+            ...aggregateResults(allSmallWorkers, actualDurationMs, allSmallWorkers.reduce((s, w) => s + w.events, 0)),
+            latency: afterStats,
+        },
+    }
+
+    const totalSmallErrors = allSmallWorkers.reduce((s, w) => s + w.errors, 0)
+    const duringP99 = duringStats.p99
+    const afterP99 = afterStats.p99
+
+    const checks = [
+        {
+            name: "import-completed",
+            expected: String(config.importTotalEvents),
+            actual: String(importResult.events),
+            pass: importResult.events === config.importTotalEvents && importResult.errors === 0,
+        },
+        {
+            name: "small-writer-zero-errors",
+            expected: "0",
+            actual: String(totalSmallErrors),
+            pass: totalSmallErrors === 0,
+        },
+        {
+            name: "during-import-p99-under-25ms",
+            expected: "< 25ms",
+            actual: `${duringP99}ms`,
+            pass: duringP99 < 25,
+        },
+        {
+            name: "during-vs-after-p99-within-20pct",
+            expected: `<= ${afterP99 > 0 ? Math.round(afterP99 * 1.2) : "N/A"}ms`,
+            actual: `${duringP99}ms`,
+            pass: afterP99 === 0 || duringP99 <= afterP99 * 1.2,
+        },
+    ]
+
+    const pass = checks.every(c => c.pass)
+
+    return {
+        id: "T4",
+        name: "Mixed Workload: Import + Concurrent Small Writes",
+        scenarios: [importScenario, duringScenario, afterScenario],
+        verification: { checks },
+        pass,
+    }
+}

--- a/packages/event-store-bench/src/scenarios/t5-raw-throughput.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t5-raw-throughput.tests.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t5-raw-throughput"
+
+describe("T5 — Raw Bulk Throughput", () => {
+    it("inserts events and verifies count", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { eventCount: 1_000 },
+        )
+
+        expect(result.id).toBe("T5")
+        expect(result.scenarios).toHaveLength(1)
+
+        const countCheck = result.verification!.checks.find(c => c.name === "event-count")
+        expect(countCheck?.pass).toBe(true)
+
+        expect(result.scenarios[0].aggregate.totalErrors).toBe(0)
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t5-raw-throughput.ts
+++ b/packages/event-store-bench/src/scenarios/t5-raw-throughput.ts
@@ -1,0 +1,98 @@
+import {
+    EventStore,
+    Query,
+    Tags,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult, VerificationResult } from "./stressTypes"
+import { ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { computeLatencyStats } from "../harness/stats"
+
+export interface T5Config {
+    eventCount: number
+}
+
+const DEFAULT_CONFIG: T5Config = { eventCount: 1_000_000 }
+
+export async function run(
+    factory: EventStoreFactory,
+    config: T5Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const eventStore = await factory(`t5-${Date.now()}`)
+
+    const CHUNK = 250_000
+    const chunkCount = Math.ceil(config.eventCount / CHUNK)
+
+    const importStart = Date.now()
+
+    for (let offset = 0; offset < config.eventCount; offset += CHUNK) {
+        const size = Math.min(CHUNK, config.eventCount - offset)
+        const chunk = Array.from({ length: size }, (_, i) => ({
+            type: "RawEvent",
+            tags: Tags.fromObj({ batch: "raw", seq: `${offset + i}` }),
+            data: { index: offset + i, payload: "x".repeat(80) },
+            metadata: {},
+        }))
+        await eventStore.append({ events: chunk })
+    }
+
+    const importElapsed = Date.now() - importStart
+    const importRate = Math.round(config.eventCount / (importElapsed / 1000))
+
+    const scenario: ScenarioResult = {
+        scenario: "T5-raw-throughput",
+        description: `${config.eventCount} unconditional events in ${chunkCount} chunks`,
+        durationMs: importElapsed,
+        workers: [{
+            workerId: 0,
+            type: "import",
+            operations: 1,
+            events: config.eventCount,
+            errors: 0,
+            conflicts: 0,
+            latencies: [importElapsed],
+        }],
+        aggregate: {
+            totalOperations: 1,
+            totalErrors: 0,
+            totalConflicts: 0,
+            opsPerSec: 1,
+            eventsPerSec: importRate,
+            latency: computeLatencyStats([importElapsed]),
+        },
+    }
+
+    const verification = await verify(eventStore, config, importElapsed)
+    const pass = verification.checks.every(c => c.pass)
+
+    return { id: "T5", name: "Raw Bulk Throughput", scenarios: [scenario], verification, pass }
+}
+
+async function verify(
+    eventStore: EventStore,
+    config: T5Config,
+    elapsedMs: number,
+): Promise<VerificationResult> {
+    const checks: VerificationResult["checks"] = []
+
+    const count = await streamAllEventsToArray(eventStore.read(Query.all(), { backwards: true, limit: 1 }))
+    const lastPos = count.length > 0 ? Number(count[0].position.toString()) : 0
+
+    checks.push({
+        name: "event-count",
+        expected: String(config.eventCount),
+        actual: String(lastPos),
+        pass: lastPos === config.eventCount,
+    })
+
+    const evPerSec = Math.round(config.eventCount / (elapsedMs / 1000))
+    checks.push({
+        name: "throughput",
+        expected: ">= 50000 ev/sec",
+        actual: `${evPerSec} ev/sec`,
+        pass: evPerSec >= 50_000,
+    })
+
+    return { checks }
+}

--- a/packages/event-store-bench/src/scenarios/t6-parallel-import.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t6-parallel-import.tests.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t6-parallel-import"
+
+describe("T6 — Parallel Bulk Import", () => {
+    it("completes parallel batches with correct counts", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { batchCount: 3, metersPerBatch: 10 },
+        )
+
+        expect(result.id).toBe("T6")
+        expect(result.scenarios).toHaveLength(1)
+
+        const batchCheck = result.verification!.checks.find(c => c.name === "all-batches-completed")
+        expect(batchCheck?.pass).toBe(true)
+
+        const countCheck = result.verification!.checks.find(c => c.name === "total-event-count")
+        expect(countCheck?.pass).toBe(true)
+        expect(countCheck?.expected).toBe(String(3 * 10 * 11))
+
+        const dupCheck = result.verification!.checks.find(c => c.name === "no-duplicate-creates")
+        expect(dupCheck?.pass).toBe(true)
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t6-parallel-import.ts
+++ b/packages/event-store-bench/src/scenarios/t6-parallel-import.ts
@@ -1,0 +1,121 @@
+import {
+    EventStore,
+    Query,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult, VerificationResult } from "./stressTypes"
+import { ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { computeLatencyStats } from "../harness/stats"
+import { buildMeterCommands, EVENTS_PER_METER } from "./factories"
+
+export interface T6Config {
+    batchCount: number
+    metersPerBatch: number
+}
+
+const DEFAULT_CONFIG: T6Config = { batchCount: 10, metersPerBatch: 2000 }
+
+export async function run(
+    factory: EventStoreFactory,
+    config: T6Config = DEFAULT_CONFIG,
+): Promise<StressTestResult> {
+    const eventStore = await factory(`t6-${Date.now()}`)
+    const totalMeters = config.batchCount * config.metersPerBatch
+    const totalEvents = totalMeters * EVENTS_PER_METER
+
+    const batchLatencies: number[] = []
+    const overallStart = Date.now()
+
+    const batchPromises = Array.from({ length: config.batchCount }, async (_, batchIdx) => {
+        const meterStart = batchIdx * config.metersPerBatch
+        const meterEnd = meterStart + config.metersPerBatch
+        const commands = buildMeterCommands(meterStart, meterEnd)
+
+        const batchStart = Date.now()
+        await eventStore.append(commands)
+        const elapsed = Date.now() - batchStart
+        batchLatencies.push(elapsed)
+        return elapsed
+    })
+
+    const batchResults = await Promise.allSettled(batchPromises)
+    const overallElapsed = Date.now() - overallStart
+
+    const fulfilled = batchResults.filter(r => r.status === "fulfilled")
+    const rejected = batchResults.filter(r => r.status === "rejected")
+    const overallRate = Math.round(totalEvents / (overallElapsed / 1000))
+
+    const scenario: ScenarioResult = {
+        scenario: "T6-parallel-import",
+        description: `${config.batchCount} parallel batches x ${config.metersPerBatch} meters = ${totalEvents} events`,
+        durationMs: overallElapsed,
+        workers: batchResults.map((r, i) => ({
+            workerId: i,
+            type: "import" as const,
+            operations: r.status === "fulfilled" ? 1 : 0,
+            events: r.status === "fulfilled" ? config.metersPerBatch * EVENTS_PER_METER : 0,
+            errors: r.status === "rejected" ? 1 : 0,
+            conflicts: 0,
+            latencies: r.status === "fulfilled" ? [r.value] : [],
+        })),
+        aggregate: {
+            totalOperations: fulfilled.length,
+            totalErrors: rejected.length,
+            totalConflicts: 0,
+            opsPerSec: Math.round(fulfilled.length / (overallElapsed / 1000)),
+            eventsPerSec: overallRate,
+            latency: computeLatencyStats(batchLatencies),
+        },
+    }
+
+    const verification = await verify(eventStore, config, totalEvents, overallElapsed, fulfilled.length)
+    const pass = verification.checks.every(c => c.pass)
+
+    return { id: "T6", name: "Parallel Bulk Import", scenarios: [scenario], verification, pass }
+}
+
+async function verify(
+    eventStore: EventStore,
+    config: T6Config,
+    expectedEvents: number,
+    elapsedMs: number,
+    completedBatches: number,
+): Promise<VerificationResult> {
+    const checks: VerificationResult["checks"] = []
+    const totalMeters = config.batchCount * config.metersPerBatch
+
+    checks.push({
+        name: "all-batches-completed",
+        expected: String(config.batchCount),
+        actual: String(completedBatches),
+        pass: completedBatches === config.batchCount,
+    })
+
+    const all = await streamAllEventsToArray(eventStore.read(Query.all()))
+    checks.push({
+        name: "total-event-count",
+        expected: String(expectedEvents),
+        actual: String(all.length),
+        pass: all.length === expectedEvents,
+    })
+
+    const createEvents = all.filter(se => se.event.type === "MeterCreated")
+    const uniqueIds = new Set(createEvents.map(se => (se.event.data as Record<string, unknown>).meterId))
+    checks.push({
+        name: "no-duplicate-creates",
+        expected: String(totalMeters),
+        actual: `${uniqueIds.size} unique, ${createEvents.length} total`,
+        pass: uniqueIds.size === createEvents.length && createEvents.length === totalMeters,
+    })
+
+    const evPerSec = Math.round(expectedEvents / (elapsedMs / 1000))
+    checks.push({
+        name: "throughput",
+        expected: ">= 10000 ev/sec",
+        actual: `${evPerSec} ev/sec`,
+        pass: evPerSec >= 10_000,
+    })
+
+    return { checks }
+}

--- a/packages/event-store-bench/src/scenarios/t8-consistency.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t8-consistency.tests.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t8-consistency"
+
+describe("T8 — Consistency Oracle", () => {
+    it("guarantees zero duplicates with concurrent writers", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { entityCount: 10, workerCount: 3, durationMs: 2_000 },
+        )
+
+        expect(result.pass).toBe(true)
+        expect(result.verification).toBeDefined()
+
+        const dupCheck = result.verification!.checks.find(c => c.name === "zero-duplicates")
+        expect(dupCheck?.pass).toBe(true)
+        expect(dupCheck?.actual).toBe("0")
+
+        const createdCheck = result.verification!.checks.find(c => c.name === "entities-created")
+        expect(createdCheck?.pass).toBe(true)
+
+        expect(result.scenarios[0].aggregate.totalErrors).toBe(0)
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t8-consistency.ts
+++ b/packages/event-store-bench/src/scenarios/t8-consistency.ts
@@ -1,0 +1,111 @@
+import {
+    EventStore,
+    AppendConditionError,
+    SequencePosition,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult, VerificationResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+import { t8EventFactory, t8QueryFactory } from "./factories"
+
+interface T8Config {
+    entityCount: number
+    workerCount: number
+    durationMs: number
+}
+
+const DEFAULT_CONFIG: T8Config = { entityCount: 200, workerCount: 20, durationMs: 60_000 }
+
+async function t8Worker(
+    eventStore: EventStore,
+    workerId: number,
+    entityCount: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    while (Date.now() < endTime) {
+        const entityIndex = Math.floor(Math.random() * entityCount) + 1
+        const query = t8QueryFactory(entityIndex)
+
+        try {
+            const existing = await streamAllEventsToArray(eventStore.read(query))
+            if (existing.length > 0) continue
+
+            const events = t8EventFactory(workerId, entityIndex)
+            const condition = { failIfEventsMatch: query, after: SequencePosition.initial() }
+
+            const opStart = Date.now()
+            await eventStore.append({ events, condition })
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += events.length
+        } catch (err) {
+            if (err instanceof AppendConditionError) {
+                result.conflicts++
+            } else {
+                result.errors++
+            }
+        }
+    }
+
+    return result
+}
+
+async function verify(eventStore: EventStore, entityCount: number): Promise<VerificationResult> {
+    const checks: VerificationResult["checks"] = []
+    let totalCreated = 0
+    let duplicates = 0
+
+    for (let i = 1; i <= entityCount; i++) {
+        const events = await streamAllEventsToArray(eventStore.read(t8QueryFactory(i)))
+        if (events.length > 1) duplicates += events.length - 1
+        if (events.length >= 1) totalCreated++
+    }
+
+    checks.push({
+        name: "zero-duplicates",
+        expected: "0",
+        actual: String(duplicates),
+        pass: duplicates === 0,
+    })
+    checks.push({
+        name: "entities-created",
+        expected: `<= ${entityCount}`,
+        actual: String(totalCreated),
+        pass: totalCreated <= entityCount,
+    })
+
+    return { checks }
+}
+
+export async function run(factory: EventStoreFactory, config: T8Config = DEFAULT_CONFIG): Promise<StressTestResult> {
+    const eventStore = await factory("t8-consistency")
+    const endTime = Date.now() + config.durationMs
+
+    const workers = await Promise.all(
+        Array.from({ length: config.workerCount }, (_, i) =>
+            t8Worker(eventStore, i, config.entityCount, endTime),
+        ),
+    )
+
+    const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+    const aggregate = aggregateResults(workers, config.durationMs, totalEvents)
+
+    const scenario: ScenarioResult = {
+        scenario: "T8",
+        description: "Consistency Oracle",
+        durationMs: config.durationMs,
+        workers,
+        aggregate,
+    }
+
+    const verification = await verify(eventStore, config.entityCount)
+    const pass = aggregate.totalErrors === 0 && verification.checks.every(c => c.pass)
+
+    return { id: "T8", name: "Consistency Oracle", scenarios: [scenario], verification, pass }
+}

--- a/packages/event-store-bench/src/scenarios/t9-overlap-consistency.tests.ts
+++ b/packages/event-store-bench/src/scenarios/t9-overlap-consistency.tests.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest"
+import { MemoryEventStore } from "@dcb-es/event-store"
+import { run } from "./t9-overlap-consistency"
+
+describe("T9 — Overlapping Scope Consistency", () => {
+    it("guarantees zero duplicates when event tags superset condition tags", async () => {
+        const result = await run(
+            () => new MemoryEventStore(),
+            { entityCount: 10, workerCount: 3, durationMs: 2_000 },
+        )
+
+        expect(result.pass).toBe(true)
+
+        const dupCheck = result.verification!.checks.find(c => c.name === "zero-duplicates")
+        expect(dupCheck?.pass).toBe(true)
+        expect(dupCheck?.actual).toBe("0")
+
+        expect(result.scenarios[0].aggregate.totalErrors).toBe(0)
+    })
+})

--- a/packages/event-store-bench/src/scenarios/t9-overlap-consistency.ts
+++ b/packages/event-store-bench/src/scenarios/t9-overlap-consistency.ts
@@ -1,0 +1,111 @@
+import {
+    EventStore,
+    AppendConditionError,
+    SequencePosition,
+    streamAllEventsToArray,
+} from "@dcb-es/event-store"
+import { StressTestResult, VerificationResult } from "./stressTypes"
+import { WorkerResult, ScenarioResult } from "../harness/types"
+import { EventStoreFactory } from "../harness/types"
+import { aggregateResults } from "../harness/stats"
+import { t9EventFactory, t9ConditionQuery, t9ReadQuery } from "./factories"
+
+interface T9Config {
+    entityCount: number
+    workerCount: number
+    durationMs: number
+}
+
+const DEFAULT_CONFIG: T9Config = { entityCount: 200, workerCount: 20, durationMs: 60_000 }
+
+async function t9Worker(
+    eventStore: EventStore,
+    workerId: number,
+    entityCount: number,
+    endTime: number,
+): Promise<WorkerResult> {
+    const result: WorkerResult = {
+        workerId, type: "write", operations: 0, events: 0, errors: 0, conflicts: 0, latencies: [],
+    }
+
+    while (Date.now() < endTime) {
+        const entityIndex = Math.floor(Math.random() * entityCount) + 1
+        const readQuery = t9ReadQuery(entityIndex)
+
+        try {
+            const existing = await streamAllEventsToArray(eventStore.read(readQuery))
+            if (existing.length > 0) continue
+
+            const events = t9EventFactory(workerId, entityIndex)
+            const condition = { failIfEventsMatch: t9ConditionQuery(entityIndex), after: SequencePosition.initial() }
+
+            const opStart = Date.now()
+            await eventStore.append({ events, condition })
+            result.latencies.push(Date.now() - opStart)
+            result.operations++
+            result.events += events.length
+        } catch (err) {
+            if (err instanceof AppendConditionError) {
+                result.conflicts++
+            } else {
+                result.errors++
+            }
+        }
+    }
+
+    return result
+}
+
+async function verify(eventStore: EventStore, entityCount: number): Promise<VerificationResult> {
+    const checks: VerificationResult["checks"] = []
+    let totalCreated = 0
+    let duplicates = 0
+
+    for (let i = 1; i <= entityCount; i++) {
+        const events = await streamAllEventsToArray(eventStore.read(t9ReadQuery(i)))
+        if (events.length > 1) duplicates += events.length - 1
+        if (events.length >= 1) totalCreated++
+    }
+
+    checks.push({
+        name: "zero-duplicates",
+        expected: "0",
+        actual: String(duplicates),
+        pass: duplicates === 0,
+    })
+    checks.push({
+        name: "entities-created",
+        expected: `<= ${entityCount}`,
+        actual: String(totalCreated),
+        pass: totalCreated <= entityCount,
+    })
+
+    return { checks }
+}
+
+export async function run(factory: EventStoreFactory, config: T9Config = DEFAULT_CONFIG): Promise<StressTestResult> {
+    const eventStore = await factory("t9-overlap")
+    const endTime = Date.now() + config.durationMs
+
+    const workers = await Promise.all(
+        Array.from({ length: config.workerCount }, (_, i) =>
+            t9Worker(eventStore, i, config.entityCount, endTime),
+        ),
+    )
+
+    const totalEvents = workers.reduce((sum, w) => sum + w.events, 0)
+    const aggregate = aggregateResults(workers, config.durationMs, totalEvents)
+
+    const scenario: ScenarioResult = {
+        scenario: "T9",
+        description: "Overlapping Scope Consistency (event tags > condition tags)",
+        durationMs: config.durationMs,
+        workers,
+        aggregate,
+    }
+
+    const verification = await verify(eventStore, config.entityCount)
+    const pass = aggregate.totalErrors === 0 && verification.checks.every(c => c.pass)
+
+    return { id: "T9", name: "Overlapping Scope Consistency", scenarios: [scenario], verification, pass }
+}

--- a/packages/event-store-bench/tsconfig.json
+++ b/packages/event-store-bench/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./dist"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["**/*.tests.ts"]
+}

--- a/packages/event-store-bench/vitest.config.ts
+++ b/packages/event-store-bench/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config"
+import path from "path"
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            "@test": path.resolve(__dirname, "../../test"),
+        },
+    },
+    test: {
+        globals: true,
+        include: ["src/**/*.tests.ts"],
+        exclude: ["src/pg.tests.ts", "src/pg-local.tests.ts"],
+        testTimeout: 120_000,
+        pool: "forks",
+        poolOptions: { forks: { singleFork: true } },
+    },
+})

--- a/packages/event-store-bench/vitest.pg-local.config.ts
+++ b/packages/event-store-bench/vitest.pg-local.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config"
+import path from "path"
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            "@test": path.resolve(__dirname, "../../test"),
+        },
+    },
+    test: {
+        globals: true,
+        include: ["src/pg-local.tests.ts"],
+        testTimeout: 120_000,
+        pool: "forks",
+        poolOptions: { forks: { singleFork: true } },
+    },
+})

--- a/packages/event-store-bench/vitest.pg.config.ts
+++ b/packages/event-store-bench/vitest.pg.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config"
+import path from "path"
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            "@test": path.resolve(__dirname, "../../test"),
+        },
+    },
+    test: {
+        globals: true,
+        include: ["src/pg.tests.ts"],
+        testTimeout: 120_000,
+        globalSetup: "../../test/vitest.globalSetup.ts",
+        pool: "forks",
+        poolOptions: { forks: { singleFork: true } },
+    },
+})

--- a/packages/event-store-postgres/src/eventStore/PostgresEventStore.ts
+++ b/packages/event-store-postgres/src/eventStore/PostgresEventStore.ts
@@ -23,7 +23,7 @@ import { analyseCommands } from "./analyseCommands.js"
 
 const VALID_IDENTIFIER = /^[a-z_][a-z0-9_]{0,62}$/i
 const READ_BATCH_SIZE = 5000
-const COPY_THRESHOLD = 10
+const COPY_THRESHOLD = 10_000
 const TAG_DELIMITER = "\x1F"
 const CONDITION_VIOLATED_SIGNAL = "APPEND_CONDITION_VIOLATED"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,27 @@ importers:
         specifier: ^9.0.8
         version: 9.0.8
 
+  packages/event-store-bench:
+    devDependencies:
+      '@dcb-es/event-store':
+        specifier: workspace:*
+        version: link:../event-store
+      '@dcb-es/event-store-postgres':
+        specifier: workspace:*
+        version: link:../event-store-postgres
+      '@testcontainers/postgresql':
+        specifier: ^10.9.0
+        version: 10.28.0
+      '@types/pg':
+        specifier: ^8.11.6
+        version: 8.20.0
+      pg:
+        specifier: ^8.11.5
+        version: 8.20.0
+      testcontainers:
+        specifier: ^10.9.0
+        version: 10.28.0
+
   packages/event-store-postgres:
     dependencies:
       '@dcb-es/event-store':


### PR DESCRIPTION
## Summary

- Add `packages/event-store-bench` — portable stress/benchmark suite (16 scenarios) that runs against any `EventStore` via factory injection
- Raise `COPY_THRESHOLD` from 10 to 10,000 in `PostgresEventStore` — benchmarked crossover point where COPY FROM beats stored procedure

## Bench scenarios

| ID | Name | What it tests |
|----|------|---------------|
| T1 | Throughput Scaling | Isolated writers at tiered concurrency |
| T2 | Bulk Import | Chunked `append(commands[])` with uniqueness conditions |
| T3 | Contention Gauntlet | N workers on single contested scope |
| T4 | Mixed Workload | Concurrent bulk import + small conditional writes |
| T5 | Raw Bulk Throughput | Large unconditional append ceiling |
| T6 | Parallel Bulk Import | N parallel batch imports on disjoint scopes |
| T8 | Consistency Oracle | Random entity creation — zero duplicates |
| T9 | Overlapping Scope | Event tags ⊃ condition tags — tests per-pair locking |
| T10 | ESB-compat | Comparable to pyeventsourcing benchmark |
| T11 | Meter Upsert | Read-decide-write with mixed state |
| T12 | Batch Throughput Sweep | Varying batch size, unconditional + conditional |
| T13 | Degradation | Throughput over multiple phases as table grows |
| T14 | Copy Threshold | Holds batch constant, varies copyThreshold setting |
| T15 | Copy vs Function Crossover | Side-by-side at each batch size |
| T16 | Batch Commands | `append(AppendCommand[])` with per-event conditions |

## COPY_THRESHOLD change

Benchmarking showed stored procedure (1 round-trip) outperforms COPY FROM (5 round-trips) at every batch size up to 10K:

| Batch | Function ev/s | COPY ev/s |
|-------|-------------|-----------|
| 500 | **266K** | 120K |
| 1,000 | **323K** | 107K |
| 5,000 | **250K** | 118K |
| 10,000 | **206K** | 120K |
| 25,000 | 75K | **130K** |

Crossover at ~10K–25K events per append.

## How to run

```bash
cd packages/event-store-bench
npm test                          # memory-only (CI, ~30s)
npm run test:pg                   # testcontainers Postgres
npm run test:pg-local             # local Mac Postgres
npx vitest run -t "T8"           # single scenario
```

## Test plan

- [x] All 27 memory tests pass
- [x] All 193 event-store-postgres tests pass with new threshold
- [x] Full pg-local suite (16 tests) passes
- [x] Architect review — clean dependency direction, no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)