### PR TITLE
chore: bump to 7.0.0-alpha.2

### DIFF
--- a/packages/event-store-postgres/package.json
+++ b/packages/event-store-postgres/package.json
@@ -3,7 +3,7 @@
     "description": "Postgres adapter for @dcb-es/event-store — persistent DCB event store with optimistic concurrency and tag-based querying",
     "author": "Paul Grimshaw",
     "license": "BSD-3-Clause",
-    "version": "7.0.0-alpha.1",
+    "version": "7.0.0-alpha.2",
     "type": "module",
     "exports": {
         ".": {
@@ -45,7 +45,7 @@
         "dist"
     ],
     "dependencies": {
-        "@dcb-es/event-store": "^7.0.0-alpha.1",
+        "@dcb-es/event-store": "^7.0.0-alpha.2",
         "pg": "^8.11.5",
         "pg-copy-streams": "^7.0.0"
     },

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dcb-es/event-store",
-    "version": "7.0.0-alpha.1",
+    "version": "7.0.0-alpha.2",
     "description": "Dynamic Consistency Boundary (DCB) event store for TypeScript — in-memory implementation, decision models, and tag-based querying",
     "type": "module",
     "license": "BSD-3-Clause",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
   packages/event-store-postgres:
     dependencies:
       '@dcb-es/event-store':
-        specifier: ^7.0.0-alpha.1
-        version: 7.0.0-alpha.1
+        specifier: ^7.0.0-alpha.2
+        version: 7.0.0-alpha.2
       pg:
         specifier: ^8.11.5
         version: 8.20.0
@@ -203,6 +203,10 @@ packages:
 
   '@dcb-es/event-store@7.0.0-alpha.1':
     resolution: {integrity: sha512-vQSOo/7vQMg3WHPm5WCJHzXM5N+/nrczDk4kyB4dDjZvettkIlvWbVR3OPfIoMTbyAZOxoPHRk83TzfyKUn73Q==}
+
+  '@dcb-es/event-store@7.0.0-alpha.2':
+    resolution: {integrity: sha512-/LSO9q062QgRgJx8gIk6dEOq/8IpdWsXFnv3FNafeNCCGNsw5MaWqxa9ZHY3VN70kjPnmIKxov6XJURIv2vQXg==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -2038,6 +2042,10 @@ snapshots:
       - pg-native
 
   '@dcb-es/event-store@7.0.0-alpha.1':
+    dependencies:
+      uuid: 9.0.1
+
+  '@dcb-es/event-store@7.0.0-alpha.2':
     dependencies:
       uuid: 9.0.1
 


### PR DESCRIPTION
## Summary
- Bump `@dcb-es/event-store` and `@dcb-es/event-store-postgres` to `7.0.0-alpha.2`
- Already published to npm with `alpha` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)