### PR TITLE
feat(event-store-bench): SST scaffold for Aurora stress testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 *.js.map
 .worktrees
 packages/*/LICENSE.md
+.sst

--- a/packages/event-store-bench/src/lambda-aurora.ts
+++ b/packages/event-store-bench/src/lambda-aurora.ts
@@ -1,0 +1,66 @@
+import { Pool } from "pg"
+import { PostgresEventStore, advisoryLocks, rowLocks } from "@dcb-es/event-store-postgres"
+import { EventStoreFactory } from "./harness/types"
+import { standardScenarios } from "./scenarios/registry"
+import { formatScenarioResult } from "./reporters/tableReporter"
+import { StressTestResult } from "./scenarios/types"
+
+let pool: Pool | undefined
+
+function getPool(): Pool {
+    if (!pool) {
+        const connectionString = process.env.PG_CONNECTION_STRING
+        if (!connectionString) throw new Error("PG_CONNECTION_STRING not set")
+        pool = new Pool({
+            connectionString,
+            max: 50,
+            ssl: process.env.PG_SSL === "false" ? false : { rejectUnauthorized: false },
+        })
+        pool.on("connect", (client) => {
+            client.query("SET synchronous_commit = off")
+        })
+    }
+    return pool
+}
+
+function getLockStrategy() {
+    return process.env.LOCK_MODE === "advisory" ? advisoryLocks() : rowLocks()
+}
+
+interface BenchEvent {
+    scenarios?: string[]
+    preset?: "quick" | "full"
+    isolated?: boolean
+}
+
+export async function handler(event: BenchEvent = {}) {
+    const { scenarios: filter, preset = "full", isolated = true } = event
+
+    const factory: EventStoreFactory = async (runId: string) => {
+        const tablePrefix = isolated ? runId.replace(/[^a-z0-9_]/gi, "_").slice(0, 40) : undefined
+        const store = new PostgresEventStore({
+            pool: getPool(),
+            tablePrefix,
+            lockStrategy: getLockStrategy(),
+        })
+        await store.ensureInstalled()
+        return store
+    }
+
+    const selected = filter
+        ? standardScenarios.filter(s => filter.includes(s.id))
+        : standardScenarios
+
+    const results: StressTestResult[] = []
+
+    for (const scenario of selected) {
+        const config = scenario.presets[preset]
+        const result = await scenario.run(factory, config)
+        for (const s of result.scenarios) {
+            console.log(formatScenarioResult(s))
+        }
+        results.push(result)
+    }
+
+    return { results }
+}

--- a/packages/event-store-bench/sst.config.ts
+++ b/packages/event-store-bench/sst.config.ts
@@ -1,0 +1,54 @@
+/// <reference path="./.sst/platform/config.d.ts" />
+
+export default $config({
+    app(input) {
+        return {
+            name: "dcb-event-store-bench",
+            removal: input?.stage === "production" ? "retain" : "remove",
+            home: "aws",
+            providers: {
+                aws: { region: process.env.AWS_REGION ?? "eu-west-1" },
+            },
+        }
+    },
+    async run() {
+        const vpc = new sst.aws.Vpc("BenchVpc", {
+            az: 2,
+            nat: "ec2",
+        })
+
+        const aurora = new sst.aws.Aurora("EventStoreDb", {
+            engine: "postgres",
+            version: "17.4",
+            vpc,
+            scaling: {
+                min: process.env.AURORA_MIN_ACU ?? "32 ACU",
+                max: process.env.AURORA_MAX_ACU ?? "64 ACU",
+            },
+            proxy: true,
+        })
+
+        const pgConnectionString = $interpolate`postgresql://${aurora.username}:${aurora.password}@${aurora.host}:${aurora.port}/${aurora.database}`
+        const lockMode = process.env.LOCK_MODE ?? "row"
+
+        const benchSuite = new sst.aws.Function("PgStressSuite", {
+            handler: "src/lambda-aurora.handler",
+            runtime: "nodejs20.x",
+            architecture: "arm64",
+            timeout: "15 minutes",
+            memory: "4096 MB",
+            vpc,
+            environment: {
+                PG_CONNECTION_STRING: pgConnectionString,
+                LOCK_MODE: lockMode,
+            },
+        })
+
+        return {
+            vpcId: vpc.id,
+            auroraHost: aurora.host,
+            auroraDatabase: aurora.database,
+            benchSuiteName: benchSuite.name,
+        }
+    },
+})


### PR DESCRIPTION
## Summary

- Adds a portable, account-agnostic SST config (`sst.config.ts`) to the bench package for deploying Aurora Serverless v2 + Lambda and running the full scenario suite against it
- Lambda handler (`lambda-aurora.ts`) reuses existing bench harness — invocable with `{ scenarios?, preset?, isolated? }`
- All config (region, ACU scaling, lock mode) via env vars — no hardcoded account/stage references
- Adds `.sst` to root `.gitignore`

### Deploy & invoke

```bash
cd packages/event-store-bench
npx sst deploy                     # deploys VPC + Aurora + Lambda
aws lambda invoke \
  --function-name <benchSuiteName> \
  --payload fileb://payload.json \
  --cli-read-timeout 900 \
  /tmp/results.json
```

### Validated

Full suite run against Aurora Serverless v2 (32-64 ACU, row locks, RDS Proxy) — 10/14 scenarios passed. 4 failures expected: contention stalling under row locks, raw-throughput threshold calibrated for local PG, oracle/overlap strict conflict counting.

## Test plan

- [x] `pnpm test` — all 351 tests pass (pre-push hook)
- [x] Deployed to AWS, invoked full bench, verified results
- [x] `sst remove` tears down cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)